### PR TITLE
fix: add Emoji Compat font to prevent connections to Google

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -132,6 +132,11 @@ flutter:
     - family: NotoEmoji
       fonts:
         - asset: fonts/NotoEmoji/NotoColorEmoji.ttf
+    - family: Noto Color Emoji Compat
+      fonts:
+        # This file is gathered from https://mvnrepository.com/artifact/androidx.emoji/emoji-bundled/
+        # Was a hazzle to find it.
+        - asset: fonts/NotoColorEmojiCompat.ttf
 
 msix_config:
   display_name: FluffyChat


### PR DESCRIPTION
This MR moves the discussion about https://gitlab.com/famedly/fluffychat/-/merge_requests/1124#note_1408677152 to a dedicated MR.

These three Noto font families are hardcoded in the Flutter engine to be loaded as fallback
from Google Fonts in case characters are supposed to be displayed that are not available in
the provided fonts.

The fonts may NOT be renamed in their family name we use in Dart.

Source : https://github.com/flutter/engine/blob/3.10.2/lib/web_ui/lib/src/engine/canvaskit/font_fallback_data.dart

Note: Two of the three mentioned fonts (`Noto Color Emoji` and `Noto Sans Symbols`) are already bundled with FLuffyChat and don't require any adjustment.

**This MR likely needs discussion, while it's relevant for privacy, it drops in the regression of 11 MiB bigger app packages.**