### PR TITLE
Fix call dialog on Android 11 + screen sharing 

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -19,7 +19,11 @@
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.BIND_TELECOM_CONNECTION_SERVICE"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
-    <uses-permission android:name="android.permission.READ_PHONE_STATE" />
+
+    <uses-permission android:name="android.permission.READ_PHONE_STATE"
+                     android:maxSdkVersion="29" />
+    <uses-permission android:name="android.permission.READ_PHONE_NUMBERS" />
+
     <uses-permission android:name="android.permission.CALL_PHONE" />
     <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />

--- a/lib/pages/dialer/dialer.dart
+++ b/lib/pages/dialer/dialer.dart
@@ -139,7 +139,7 @@ class MyCallingPage extends State<Calling> {
   Room? get room => call.room;
 
   String get displayName => call.room.getLocalizedDisplayname(
-        MatrixLocals(L10n.of(context)!),
+        MatrixLocals(L10n.of(widget.context)!),
       );
 
   String get callId => widget.callId;
@@ -248,18 +248,18 @@ class MyCallingPage extends State<Calling> {
 
   void _resizeLocalVideo(Orientation orientation) {
     final shortSide = min(
-      MediaQuery.of(context).size.width,
-      MediaQuery.of(context).size.height,
+      MediaQuery.of(widget.context).size.width,
+      MediaQuery.of(widget.context).size.height,
     );
     _localVideoMargin = remoteStream != null
         ? const EdgeInsets.only(top: 20.0, right: 20.0)
         : EdgeInsets.zero;
     _localVideoWidth = remoteStream != null
         ? shortSide / 3
-        : MediaQuery.of(context).size.width;
+        : MediaQuery.of(widget.context).size.width;
     _localVideoHeight = remoteStream != null
         ? shortSide / 4
-        : MediaQuery.of(context).size.height;
+        : MediaQuery.of(widget.context).size.height;
   }
 
   void _handleCallState(CallState state) {
@@ -309,14 +309,15 @@ class MyCallingPage extends State<Calling> {
           androidNotificationOptions: AndroidNotificationOptions(
             channelId: 'notification_channel_id',
             channelName: 'Foreground Notification',
-            channelDescription: L10n.of(context)!.foregroundServiceRunning,
+            channelDescription:
+                L10n.of(widget.context)!.foregroundServiceRunning,
           ),
           iosNotificationOptions: const IOSNotificationOptions(),
           foregroundTaskOptions: const ForegroundTaskOptions(),
         );
         FlutterForegroundTask.startService(
-          notificationTitle: L10n.of(context)!.screenSharingTitle,
-          notificationText: L10n.of(context)!.screenSharingDetail,
+          notificationTitle: L10n.of(widget.context)!.screenSharingTitle,
+          notificationText: L10n.of(widget.context)!.screenSharingDetail,
         );
       } else {
         FlutterForegroundTask.stopService();
@@ -379,7 +380,7 @@ class MyCallingPage extends State<Calling> {
       child: Icon(_speakerOn ? Icons.volume_up : Icons.volume_off),
       onPressed: _switchSpeaker,
       foregroundColor: Colors.black54,
-      backgroundColor: Theme.of(context).backgroundColor,
+      backgroundColor: Theme.of(widget.context).backgroundColor,
     );
     */
     final hangupButton = FloatingActionButton(
@@ -481,7 +482,7 @@ class MyCallingPage extends State<Calling> {
       var title = '';
       if (call.localHold) {
         title = '${call.room.getLocalizedDisplayname(
-          MatrixLocals(L10n.of(context)!),
+          MatrixLocals(L10n.of(widget.context)!),
         )} held the call.';
       } else if (call.remoteOnHold) {
         title = 'You held the call.';

--- a/lib/utils/voip_plugin.dart
+++ b/lib/utils/voip_plugin.dart
@@ -61,7 +61,8 @@ class VoipPlugin with WidgetsBindingObserver implements WebRTCDelegate {
   void addCallingOverlay(String callId, CallSession call) {
     final context = kIsWeb
         ? ChatList.contextForVoip!
-        : FluffyChatApp.routerKey.currentContext!; // web is weird
+        : FluffyChatApp.matrixKey.currentContext!; // web is weird
+
     if (overlayEntry != null) {
       Logs().e('[VOIP] addCallingOverlay: The call session already exists?');
       overlayEntry!.remove();
@@ -165,7 +166,7 @@ class VoipPlugin with WidgetsBindingObserver implements WebRTCDelegate {
         addCallingOverlay(call.callId, call);
         try {
           if (!hasCallingAccount) {
-            ScaffoldMessenger.of(FluffyChatApp.routerKey.currentContext!)
+            ScaffoldMessenger.of(FluffyChatApp.matrixKey.currentContext!)
                 .showSnackBar(
               const SnackBar(
                 content: Text(

--- a/lib/widgets/fluffy_chat_app.dart
+++ b/lib/widgets/fluffy_chat_app.dart
@@ -17,6 +17,7 @@ class FluffyChatApp extends StatefulWidget {
   final List<Client> clients;
   final Map<String, String>? queryParameters;
   static GlobalKey<VRouterState> routerKey = GlobalKey<VRouterState>();
+  static GlobalKey<MatrixState> matrixKey = GlobalKey<MatrixState>();
   const FluffyChatApp({
     Key? key,
     this.testWidget,
@@ -75,6 +76,7 @@ class FluffyChatAppState extends State<FluffyChatApp> {
             initialUrl: _initialUrl ?? '/',
             routes: AppRoutes(columnMode ?? false).routes,
             builder: (context, child) => Matrix(
+              key: FluffyChatApp.matrixKey,
               context: context,
               router: FluffyChatApp.routerKey,
               clients: widget.clients,


### PR DESCRIPTION
# Description
Fixes #1164 , some of #963
Can now call consistently between Element Web and FluffyChat Android.

### Please mark on which platform you have tested the changes:

 - [x] Android
 - [ ] iOS
- [ ] Web
- [ ] Linux
- [ ] Windows
- [ ] macOS