### PR TITLE
fix: code cannot be wrap

### DIFF
--- a/lib/pages/chat/events/html_message.dart
+++ b/lib/pages/chat/events/html_message.dart
@@ -49,20 +49,17 @@ class HtmlMessage extends StatelessWidget {
     final linkifiedRenderHtml = linkify(
       renderHtml,
       options: const LinkifyOptions(humanize: false),
-    )
-        .map(
-          (element) {
-            if (element is! UrlElement ||
-                element.text.contains('<') ||
-                element.text.contains('>') ||
-                element.text.contains('"')) {
-              return element.text;
-            }
-            return '<a href="${element.url}">${element.text}</a>';
-          },
-        )
-        .join('')
-        .replaceAll('\n', '');
+    ).map(
+      (element) {
+        if (element is! UrlElement ||
+            element.text.contains('<') ||
+            element.text.contains('>') ||
+            element.text.contains('"')) {
+          return element.text;
+        }
+        return '<a href="${element.url}">${element.text}</a>';
+      },
+    ).join('');
 
     final linkColor = textColor.withAlpha(150);
 


### PR DESCRIPTION
I think it is a wrong fix for link, '\n' should not be replaceAll, so I think this should be reverted