### PR TITLE
Scalable image preview for room avatars and profile images

### DIFF
--- a/lib/pages/chat/events/image_bubble.dart
+++ b/lib/pages/chat/events/image_bubble.dart
@@ -74,7 +74,7 @@ class ImageBubble extends StatelessWidget {
     showDialog(
       context: Matrix.of(context).navigatorContext,
       useRootNavigator: false,
-      builder: (_) => ImageViewer(event),
+      builder: (_) => ImageViewer(event, null),
     );
   }
 

--- a/lib/pages/chat_details/chat_details_view.dart
+++ b/lib/pages/chat_details/chat_details_view.dart
@@ -15,11 +15,21 @@ import 'package:fluffychat/widgets/chat_settings_popup_menu.dart';
 import 'package:fluffychat/widgets/layouts/max_width_body.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 import '../../utils/url_launcher.dart';
+import '../image_viewer/image_viewer.dart';
 
 class ChatDetailsView extends StatelessWidget {
   final ChatDetailsController controller;
 
   const ChatDetailsView(this.controller, {Key? key}) : super(key: key);
+
+  void _onTap(BuildContext context, Uri? avatar) {
+    if (avatar == null) return;
+    showDialog(
+      context: Matrix.of(context).navigatorContext,
+      useRootNavigator: false,
+      builder: (_) => ImageViewer(null, avatar),
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -112,6 +122,8 @@ class ChatDetailsView extends StatelessWidget {
                                         name: displayname,
                                         size: Avatar.defaultSize * 2.5,
                                         fontSize: 18 * 2.5,
+                                        onTap: () =>
+                                            _onTap(context, room.avatar),
                                       ),
                                     ),
                                   ),

--- a/lib/pages/image_viewer/image_viewer.dart
+++ b/lib/pages/image_viewer/image_viewer.dart
@@ -8,10 +8,15 @@ import 'package:fluffychat/utils/platform_infos.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 import '../../utils/matrix_sdk_extensions/event_extension.dart';
 
+/// A widget showing an image in fullscreen, allowing users to zoom in and out.
+///
+/// Either an event or an uri of the image must be provided.
+/// When providing an event, the top bar additionally allows users to reply to, share, or download the image.
 class ImageViewer extends StatefulWidget {
-  final Event event;
+  final Event? event;
+  final Uri? uri;
 
-  const ImageViewer(this.event, {Key? key}) : super(key: key);
+  const ImageViewer(this.event, this.uri, {Key? key}) : super(key: key);
 
   @override
   ImageViewerController createState() => ImageViewerController();
@@ -20,15 +25,16 @@ class ImageViewer extends StatefulWidget {
 class ImageViewerController extends State<ImageViewer> {
   /// Forward this image to another room.
   void forwardAction() {
-    Matrix.of(context).shareContent = widget.event.content;
+    Matrix.of(context).shareContent = widget.event?.content;
     context.go('/rooms');
   }
 
-  /// Save this file with a system call.
-  void saveFileAction(BuildContext context) => widget.event.saveFile(context);
+  /// Save this file with a system call. Only ever will be called for events.
+  void saveFileAction(BuildContext context) => widget.event?.saveFile(context);
 
-  /// Save this file with a system call.
-  void shareFileAction(BuildContext context) => widget.event.shareFile(context);
+  /// Save this file with a system call. Only ever will be called for events.
+  void shareFileAction(BuildContext context) =>
+      widget.event?.shareFile(context);
 
   static const maxScaleFactor = 1.5;
 

--- a/lib/pages/image_viewer/image_viewer_view.dart
+++ b/lib/pages/image_viewer/image_viewer_view.dart
@@ -25,31 +25,33 @@ class ImageViewerView extends StatelessWidget {
           tooltip: L10n.of(context)!.close,
         ),
         backgroundColor: const Color(0x44000000),
-        actions: [
-          IconButton(
-            icon: const Icon(Icons.reply_outlined),
-            onPressed: controller.forwardAction,
-            color: Colors.white,
-            tooltip: L10n.of(context)!.share,
-          ),
-          if (!PlatformInfos.isIOS)
-            IconButton(
-              icon: const Icon(Icons.download_outlined),
-              onPressed: () => controller.saveFileAction(context),
-              color: Colors.white,
-              tooltip: L10n.of(context)!.downloadFile,
-            ),
-          if (PlatformInfos.isMobile)
-            // Use builder context to correctly position the share dialog on iPad
-            Builder(
-              builder: (context) => IconButton(
-                onPressed: () => controller.shareFileAction(context),
-                tooltip: L10n.of(context)!.share,
-                color: Colors.white,
-                icon: Icon(Icons.adaptive.share_outlined),
-              ),
-            )
-        ],
+        actions: controller.widget.event != null
+            ? [
+                IconButton(
+                  icon: const Icon(Icons.reply_outlined),
+                  onPressed: controller.forwardAction,
+                  color: Colors.white,
+                  tooltip: L10n.of(context)!.share,
+                ),
+                if (!PlatformInfos.isIOS)
+                  IconButton(
+                    icon: const Icon(Icons.download_outlined),
+                    onPressed: () => controller.saveFileAction(context),
+                    color: Colors.white,
+                    tooltip: L10n.of(context)!.downloadFile,
+                  ),
+                if (PlatformInfos.isMobile)
+                  // Use builder context to correctly position the share dialog on iPad
+                  Builder(
+                    builder: (context) => IconButton(
+                      onPressed: () => controller.shareFileAction(context),
+                      tooltip: L10n.of(context)!.share,
+                      color: Colors.white,
+                      icon: Icon(Icons.adaptive.share_outlined),
+                    ),
+                  ),
+              ]
+            : null,
       ),
       body: InteractiveViewer(
         minScale: 1.0,
@@ -57,8 +59,9 @@ class ImageViewerView extends StatelessWidget {
         onInteractionEnd: controller.onInteractionEnds,
         child: Center(
           child: Hero(
-            tag: controller.widget.event.eventId,
+            tag: controller.widget.event?.eventId ?? controller.widget.uri!,
             child: MxcImage(
+              uri: controller.widget.uri,
               event: controller.widget.event,
               fit: BoxFit.contain,
               isThumbnail: false,

--- a/lib/pages/user_bottom_sheet/user_bottom_sheet_view.dart
+++ b/lib/pages/user_bottom_sheet/user_bottom_sheet_view.dart
@@ -6,12 +6,22 @@ import 'package:matrix/matrix.dart';
 import 'package:fluffychat/utils/fluffy_share.dart';
 import 'package:fluffychat/widgets/avatar.dart';
 import '../../widgets/matrix.dart';
+import '../image_viewer/image_viewer.dart';
 import 'user_bottom_sheet.dart';
 
 class UserBottomSheetView extends StatelessWidget {
   final UserBottomSheetController controller;
 
   const UserBottomSheetView(this.controller, {Key? key}) : super(key: key);
+
+  void _onTap(BuildContext context) {
+    if (controller.widget.user?.avatarUrl == null) return;
+    showDialog(
+      context: Matrix.of(context).navigatorContext,
+      useRootNavigator: false,
+      builder: (_) => ImageViewer(null, controller.widget.user?.avatarUrl),
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -76,6 +86,7 @@ class UserBottomSheetView extends StatelessWidget {
                       name: displayname,
                       size: Avatar.defaultSize * 2.5,
                       fontSize: 18 * 2.5,
+                      onTap: () => _onTap(context),
                     ),
                   ),
                 ),

--- a/lib/widgets/content_banner.dart
+++ b/lib/widgets/content_banner.dart
@@ -12,6 +12,7 @@ class ContentBanner extends StatelessWidget {
   final Client? client;
   final double opacity;
   final WidgetBuilder? placeholder;
+  final void Function()? onTap;
 
   const ContentBanner({
     this.mxContent,
@@ -21,61 +22,68 @@ class ContentBanner extends StatelessWidget {
     this.client,
     this.opacity = 0.75,
     this.placeholder,
+    this.onTap,
     Key? key,
   }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
     final onEdit = this.onEdit;
-    return Container(
-      height: height,
-      alignment: Alignment.center,
-      decoration: BoxDecoration(
-        color: Theme.of(context).colorScheme.secondaryContainer,
-      ),
-      child: Stack(
-        children: <Widget>[
-          Positioned(
-            left: 0,
-            right: 0,
-            top: 0,
-            bottom: 0,
-            child: Opacity(
-              opacity: opacity,
-              child: mxContent == null
-                  ? Center(
-                      child: Icon(
-                        defaultIcon,
-                        color:
-                            Theme.of(context).colorScheme.onSecondaryContainer,
-                        size: 128,
+    return GestureDetector(
+      onTap: () {
+        if (onTap != null) onTap!();
+      },
+      child: Container(
+        height: height,
+        alignment: Alignment.center,
+        decoration: BoxDecoration(
+          color: Theme.of(context).colorScheme.secondaryContainer,
+        ),
+        child: Stack(
+          children: <Widget>[
+            Positioned(
+              left: 0,
+              right: 0,
+              top: 0,
+              bottom: 0,
+              child: Opacity(
+                opacity: opacity,
+                child: mxContent == null
+                    ? Center(
+                        child: Icon(
+                          defaultIcon,
+                          color: Theme.of(context)
+                              .colorScheme
+                              .onSecondaryContainer,
+                          size: 128,
+                        ),
+                      )
+                    : MxcImage(
+                        key: Key(mxContent?.toString() ?? 'NoKey'),
+                        uri: mxContent,
+                        animated: true,
+                        fit: BoxFit.cover,
+                        placeholder: placeholder,
+                        height: 400,
+                        width: 800,
                       ),
-                    )
-                  : MxcImage(
-                      key: Key(mxContent?.toString() ?? 'NoKey'),
-                      uri: mxContent,
-                      animated: true,
-                      fit: BoxFit.cover,
-                      placeholder: placeholder,
-                      height: 400,
-                      width: 800,
-                    ),
-            ),
-          ),
-          if (onEdit != null)
-            Container(
-              margin: const EdgeInsets.all(8),
-              alignment: Alignment.bottomRight,
-              child: FloatingActionButton(
-                mini: true,
-                heroTag: null,
-                onPressed: onEdit,
-                backgroundColor: Theme.of(context).colorScheme.background,
-                foregroundColor: Theme.of(context).textTheme.bodyLarge?.color,
-                child: const Icon(Icons.camera_alt_outlined),
               ),
             ),
-        ],
+            if (onEdit != null)
+              Container(
+                margin: const EdgeInsets.all(8),
+                alignment: Alignment.bottomRight,
+                child: FloatingActionButton(
+                  mini: true,
+                  heroTag: null,
+                  onPressed: onEdit,
+                  backgroundColor: Theme.of(context).colorScheme.background,
+                  foregroundColor: Theme.of(context).textTheme.bodyLarge?.color,
+                  child: const Icon(Icons.camera_alt_outlined),
+                ),
+              ),
+          ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
Hey,
this PR adds scalable (/zoomable) previews of room avatars and profile images, similar to how it's already possible for normal images that are sent in chats.
The image viewer can be found when clicking on a profile image in the user bottom sheet or when tapping the room avatar in the chat details.

Concerning the implementation: I had the feeling that the preview would share too much code with the existing `ImageViewer` for Matrix events containing images, thus they're currently both using the same component.
It'd be possible to create a new separate `ImageViewer` component only, but I'm not sure if the boilerplate code would be worth it.

And sorry for all the reformatting caused by the changes, unfortunately that seems to be necessary for the CI to pass.