### PR TITLE
small performance tweaks for Message

### DIFF
--- a/lib/pages/chat/events/message.dart
+++ b/lib/pages/chat/events/message.dart
@@ -75,11 +75,11 @@ class Message extends StatelessWidget {
         nextEvent == null ||
         !event.originServerTs.sameEnvironment(nextEvent!.originServerTs);
     final sameSender = nextEvent != null &&
-        [
+        {
           EventTypes.Message,
           EventTypes.Sticker,
           EventTypes.Encrypted,
-        ].contains(nextEvent!.type) &&
+        }.contains(nextEvent!.type) &&
         nextEvent?.relationshipType == null &&
         nextEvent!.senderId == event.senderId &&
         !displayTime;
@@ -407,13 +407,11 @@ class Message extends StatelessWidget {
               : Theme.of(context).primaryColor.withAlpha(0),
           constraints:
               const BoxConstraints(maxWidth: FluffyThemes.columnWidth * 2.5),
-          child: Padding(
-            padding: EdgeInsets.symmetric(
-              horizontal: 8.0,
-              vertical: 4.0 * AppConfig.bubbleSizeFactor,
-            ),
-            child: container,
+          padding: EdgeInsets.symmetric(
+            horizontal: 8.0,
+            vertical: 4.0 * AppConfig.bubbleSizeFactor,
           ),
+          child: container,
         ),
       ),
     );


### PR DESCRIPTION
It is the widget most often built, so every small bit helps.
- replace a List with an array (should be easier to optimize for the compiler)
- remove a Padding widget and use the parent Container's padding instead