### PR TITLE
chore: bump matrix sdk

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1137,10 +1137,10 @@ packages:
     dependency: "direct main"
     description:
       name: matrix
-      sha256: "246499026eff75252dc47aef509760eff1508d541a33c0a9964cc1377b2bfd4c"
+      sha256: "8fa5d10ca27880fbf98143a36099f4d610d4772f847e6d97fa94dc20c11e450e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.22.0"
+    version: "0.22.2"
   matrix_api_lite:
     dependency: transitive
     description:


### PR DESCRIPTION
Fixed display name computation for direct chats on Conduit, a feature very relevant for me 🥺 ...