### PR TITLE
fix: Metadata leak in voice message

### DIFF
--- a/lib/pages/chat/chat.dart
+++ b/lib/pages/chat/chat.dart
@@ -31,6 +31,7 @@ import 'package:fluffychat/utils/matrix_sdk_extensions/event_extension.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/matrix_locals.dart';
 import 'package:fluffychat/utils/platform_infos.dart';
 import 'package:fluffychat/widgets/matrix.dart';
+import 'package:fluffychat/utils/metadata_nuller.dart';
 import '../../utils/account_bundles.dart';
 import '../../utils/localized_exception_extension.dart';
 import '../../utils/matrix_sdk_extensions/matrix_file_extension.dart';
@@ -617,8 +618,10 @@ class ChatController extends State<ChatPageWithRoom> {
     );
     if (result == null) return;
     final audioFile = File(result.path);
+    var audioFileBytes = audioFile.readAsBytesSync();
+    nullMetadata(audioFileBytes);
     final file = MatrixAudioFile(
-      bytes: audioFile.readAsBytesSync(),
+      bytes: audioFileBytes,
       name: audioFile.path,
     );
     await room.sendFileEvent(

--- a/lib/utils/metadata_nuller.dart
+++ b/lib/utils/metadata_nuller.dart
@@ -1,0 +1,28 @@
+import 'dart:typed_data';
+
+const uint32Size = 4;
+// 32bits unsigned integers representing mp4 atoms
+const ftypAtom = 0x66747970; // 'ftyp'
+const metaAtom = 0x6d657461; // 'meta'
+const freeAtom = 0x66726565; // 'free'
+
+void metadataNuller(Uint8List file) {
+  final blob = ByteData.sublistView(file);
+  final bool isMp4Container =
+      blob.getUint32(uint32Size, Endian.big) == ftypAtom;
+  if (!isMp4Container) {
+    return;
+  }
+
+  var i = 0;
+  while (i < (blob.lengthInBytes - uint32Size) &&
+      blob.getUint32(i, Endian.big) != freeAtom) {
+    if (blob.getUint32(i, Endian.big) == metaAtom) {
+      final size = blob.getUint32(i - uint32Size, Endian.big);
+      final offset = i + uint32Size;
+      file.fillRange(offset, offset + size, 0);
+      break;
+    }
+    i += 1;
+  }
+}

--- a/lib/utils/metadata_nuller.dart
+++ b/lib/utils/metadata_nuller.dart
@@ -6,7 +6,7 @@ const ftypAtom = 0x66747970; // 'ftyp'
 const metaAtom = 0x6d657461; // 'meta'
 const freeAtom = 0x66726565; // 'free'
 
-void metadataNuller(Uint8List file) {
+void nullMetadata(Uint8List file) {
   final blob = ByteData.sublistView(file);
   final bool isMp4Container =
       blob.getUint32(uint32Size, Endian.big) == ftypAtom;


### PR DESCRIPTION
This pull request addresses the issue of leaking some metadata on voice messages by setting it to 0. Note that it only works on `mp4` container and will do nothing otherwise.

Fixes [413](https://github.com/krille-chan/fluffychat/issues/413).