### PR TITLE
feat: Dynamic theming for emoji keyboard

### DIFF
--- a/assets/l10n/intl_en.arb
+++ b/assets/l10n/intl_en.arb
@@ -776,6 +776,11 @@
         "type": "text",
         "placeholders": {}
     },
+    "emoteKeyboardNoRecents": "Recently-used emotes will appear here...",
+    "@emoteKeyboardNoRecents": {
+        "type": "text",
+        "placeholders": {}
+    },
     "emotePacks": "Emote packs for room",
     "@emotePacks": {
         "type": "text",

--- a/lib/pages/chat/chat_emoji_picker.dart
+++ b/lib/pages/chat/chat_emoji_picker.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import 'package:emoji_picker_flutter/emoji_picker_flutter.dart';
+import 'package:flutter_gen/gen_l10n/l10n.dart';
 
 import 'package:fluffychat/config/themes.dart';
 import 'chat.dart';
@@ -11,6 +12,7 @@ class ChatEmojiPicker extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
     return AnimatedContainer(
       duration: FluffyThemes.animationDuration,
       curve: FluffyThemes.animationCurve,
@@ -21,6 +23,27 @@ class ChatEmojiPicker extends StatelessWidget {
           ? EmojiPicker(
               onEmojiSelected: controller.onEmojiSelected,
               onBackspacePressed: controller.emojiPickerBackspace,
+              config: Config(
+                backspaceColor: theme.colorScheme.primary,
+                bgColor: Color.lerp(
+                  theme.colorScheme.background,
+                  theme.colorScheme.primaryContainer,
+                  0.25,
+                )!,
+                iconColor: theme.colorScheme.primary.withOpacity(0.5),
+                iconColorSelected: theme.colorScheme.primary,
+                indicatorColor: theme.colorScheme.primary,
+                noRecents: Text(
+                  L10n.of(context)!.emoteKeyboardNoRecents,
+                  style: theme.textTheme.bodyLarge,
+                ),
+                skinToneDialogBgColor: Color.lerp(
+                  theme.colorScheme.background,
+                  theme.colorScheme.primaryContainer,
+                  0.75,
+                )!,
+                skinToneIndicatorColor: theme.colorScheme.onBackground,
+              ),
             )
           : null,
     );


### PR DESCRIPTION
Fixes #504 by using `emoji_picker_flutter`'s new features: customizable color scheme (which was not implemented when I introduced GitLab MR !1051 back then)

Before:
![Before](https://user-images.githubusercontent.com/7829231/258666292-32bf3ad8-3d13-463b-8973-8f03e6f34c05.png)

After:
![Screenshot_20230903_001021.jpg](https://github.com/krille-chan/fluffychat/assets/17312341/7e1c8439-2daf-4abc-a816-5412f40cb17f)



Considering that there are multiple PRs related to emotes and emojis, I have reviewed that this PR:

+ **May likely to conflict with:**
  - #1: PR completely replaces the default emoji picker design, but this PR may be merged as an existing workaround to #504
  - #454: PR possibly triyng to fix GitLab issue !401, but introduces `noRecentEmojis` on l10n data (which this PR prefers `emoteKeyboardNoRecents` instead) with similar purpose, also converted `ChatEmojiPicker` into a `StatefulWidget`
    * My PR can be closed to favor #454's implementation (just add the necessary color theme settings), but it may also conflict with #1's plans reimplement the picker from scratch
+ **May not conflict with:** #450, #455