### PR TITLE
Use locally hosted canvaskit instead of calling google

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ COPY . /app
 WORKDIR /app
 RUN ./scripts/prepare-web.sh
 RUN flutter pub get
-RUN flutter build web --release --source-maps
+RUN flutter build web --dart-define=FLUTTER_WEB_CANVASKIT_URL=canvaskit/ --release --source-maps
 
 FROM docker.io/nginx:alpine
 RUN rm -rf /usr/share/nginx/html


### PR DESCRIPTION
Related to #451, but about canvaskit instead of fonts.

Sources:
- https://github.com/flutter/flutter/issues/118473
- https://github.com/flutter/engine/blob/7b2db6dbe1c49a8004ff865607988eec36868ccc/lib/web_ui/lib/src/engine/canvaskit/initialization.dart#L51