### PR TITLE
fix: LoadProfileBottomSheet accessing disposed outerContext

### DIFF
--- a/lib/pages/user_bottom_sheet/user_bottom_sheet.dart
+++ b/lib/pages/user_bottom_sheet/user_bottom_sheet.dart
@@ -233,7 +233,10 @@ class UserBottomSheetController extends State<UserBottomSheet> {
         );
         if (roomIdResult.error != null) return;
         widget.outerContext.go('/rooms/${roomIdResult.result!}');
-        Navigator.of(context, rootNavigator: false).pop();
+        Navigator.of(context, rootNavigator: false)
+          ..pop()
+          ..pop();
+        widget.outerContext.go('/rooms/${roomIdResult.result!}');
         break;
       case UserBottomSheetAction.ignore:
         context.go('/rooms/settings/security/ignorelist');


### PR DESCRIPTION
fixes #644 

The following code is causing the issue:
It only pops `UserBottomSheet`, and leaves the `LoadProfileBottomSheet` to access the stale `outerContext` even after navigation is done.
```
case UserBottomSheetAction.message:
        //more code
        widget.outerContext.go('/rooms/${roomIdResult.result!}');
        Navigator.of(context, rootNavigator: false).pop();
        break;
```