### PR TITLE
Fix Dockerfile: install jq in the builder image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM ghcr.io/cirruslabs/flutter as builder
-RUN sudo apt update && sudo apt install curl -y
+RUN sudo apt update && sudo apt install curl jq -y
 COPY . /app
 WORKDIR /app
 RUN ./scripts/prepare-web.sh


### PR DESCRIPTION
It seems jq is now required by the prepare-web.sh script, so add it in the builder image.