### PR TITLE
fix: call gui not visible on devices with android version > android 11

### DIFF
--- a/assets/l10n/intl_en.arb
+++ b/assets/l10n/intl_en.arb
@@ -1190,6 +1190,11 @@
         "type": "text",
         "placeholders": {}
     },
+    "phonePermissionDeniedNotice": "Phone permission denied. Please grant it to be able to properly send and recieve calls.",
+    "@phonePermissionDeniedNotice": {
+        "type": "text",
+        "placeholders": {}
+    },
     "login": "Login",
     "@login": {
         "type": "text",

--- a/lib/pages/chat_list/chat_list.dart
+++ b/lib/pages/chat_list/chat_list.dart
@@ -378,7 +378,7 @@ class ChatListController extends State<ChatList>
     scrollController.addListener(_onScroll);
     _waitForFirstSync();
     _hackyWebRTCFixForWeb();
-    CallKeepManager().initialize();
+    CallKeepManager().initialize(context: context);
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       if (mounted) {
         searchServer =


### PR DESCRIPTION
fixes #499 #500 

On devices greater than android 11, `read_phone_state` permission is required to be consented during runtime.
