### PR TITLE
Change dead link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,4 +66,4 @@ Please visit the [Wiki](https://github.com/krille-chan/fluffychat/wiki) for buil
 
 * <a href="https://github.com/madsrh/WoodenBeaver">WoodenBeaver</a> sound theme for the notification sound.
 
-* The Matrix Foundation for making and maintaining the [emoji translations](https://github.com/matrix-org/matrix-doc/blob/main/data-definitions/sas-emoji.json) used for emoji verification, licensed Apache 2.0
+* The Matrix Foundation for making and maintaining the [emoji translations](https://github.com/matrix-org/matrix-spec/blob/main/data-definitions/sas-emoji.json) used for emoji verification, licensed Apache 2.0


### PR DESCRIPTION
Seems like it was removed from the MSC repo at some point.