### PR TITLE
Fix: Fockerfile, yq dependency in scripts/prepare-web.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,15 @@
 FROM ghcr.io/cirruslabs/flutter as builder
-RUN sudo apt update && sudo apt install curl jq -y
+RUN sudo apt update && sudo apt install curl wget jq -y
+
+WORKDIR /tmp
+RUN wget https://github.com/mikefarah/yq/releases/download/v4.40.5/yq_linux_amd64.tar.gz
+RUN tar -xzvf ./yq_linux_amd64.tar.gz
+RUN mv yq_linux_amd64 /usr/bin/yq
+
 COPY . /app
 WORKDIR /app
 RUN ./scripts/prepare-web.sh
+COPY config.* /app/
 RUN flutter pub get
 RUN flutter build web --dart-define=FLUTTER_WEB_CANVASKIT_URL=canvaskit/ --release --source-maps
 


### PR DESCRIPTION
Fix dependency. missing yq when invoking setup-web. also ensure updated config.json copied

Current Docker file will error:

```
[+] Building 13.0s (12/16)
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                                      0.0s
 => => transferring dockerfile: 429B                                                                                                                                                                                                                                      0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                                                         0.0s
 => => transferring context: 2B                                                                                                                                                                                                                                           0.0s
 => [internal] load metadata for docker.io/library/nginx:alpine                                                                                                                                                                                                           2.8s
 => [internal] load metadata for ghcr.io/cirruslabs/flutter:latest                                                                                                                                                                                                        2.4s
 => [auth] cirruslabs/flutter:pull token for ghcr.io                                                                                                                                                                                                                      0.0s
 => [builder 1/7] FROM ghcr.io/cirruslabs/flutter@sha256:d37cffe5cabbe96f1c59ba5f0d5166f3d7043324279858ba2982e36d1d7361dc                                                                                                                                                 0.0s
 => [stage-1 1/3] FROM docker.io/library/nginx:alpine@sha256:a59278fd22a9d411121e190b8cec8aa57b306aa3332459197777583beb728f59                                                                                                                                             0.0s
 => [internal] load build context                                                                                                                                                                                                                                         5.6s
 => => transferring context: 210.73MB                                                                                                                                                                                                                                     5.5s
 => CACHED [builder 2/7] RUN sudo apt update && sudo apt install curl jq -y                                                                                                                                                                                               0.0s
 => [builder 3/7] COPY . /app                                                                                                                                                                                                                                             2.5s
 => [builder 4/7] WORKDIR /app                                                                                                                                                                                                                                            0.0s
 => ERROR [builder 5/7] RUN ./scripts/prepare-web.sh                                                                                                                                                                                                                      0.7s
------
 > [builder 5/7] RUN ./scripts/prepare-web.sh:
#13 0.680 #!/bin/sh -ve
#13 0.680 rm -r assets/js/package
#13 0.686
#13 0.686 OLM_VERSION=$(cat pubspec.yaml | yq .dependencies.flutter_olm)
#13 0.688 ./scripts/prepare-web.sh: 4: yq: not found
------
executor failed running [/bin/sh -c ./scripts/prepare-web.sh]: exit code: 127
```

This change just adds the missing yq package in the most straightforward way I could think (just wget and extract).

Tested with and without a set config.json

Note: This replaces PR774 with a signed commit as requested
