### PR TITLE
fix: HTML renderer edge-case without top-level element

### DIFF
--- a/lib/pages/chat/events/html_message.dart
+++ b/lib/pages/chat/events/html_message.dart
@@ -88,7 +88,13 @@ class HtmlMessage extends StatelessWidget {
       padding: HtmlPaddings.only(left: 6, bottom: 0),
     );
 
-    final element = _linkifyHtml(HtmlParser.parseHTML(renderHtml));
+    // I encountered messages containing only a String with several HTML elements - without a common parent containing
+    // them - in this case, we'd end up with *several* top level elements - and the HTML parser fails
+    //
+    // We hence add an inline-block `<div>` around the entire message in order to ensure we're dealing with a single
+    // top-level element.
+    final paddedHtml = '<div style="display: inline-block;">$renderHtml</div>';
+    final element = _linkifyHtml(HtmlParser.parseHTML(paddedHtml));
 
     // there is no need to pre-validate the html, as we validate it while rendering
     return Html.fromElement(


### PR DESCRIPTION
The PR contains two commit : 

- first one only fixes the relevant issue
- second removes previous workaround applying <p> elements around links since that's less efficient and no longer needed with the patch also catching several top-level elements on message base

In case you only want to use the pure workaround without the cleanup, feel free to cherry-pick the first commit only.

Test on message content :

```
<p> Test paragraph !</p>
<pre>
Some
Content
Here
</pre>
```

Note that the sample has no containing HTML parent but consists of _several_ Nodes instead of only one.