### PR TITLE
Added Docker deploy step to release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,6 +9,10 @@ concurrency:
   group: release_workflow
   cancel-in-progress: true
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
 jobs:
   build_web:
     runs-on: ubuntu-latest
@@ -197,3 +201,30 @@ jobs:
           else
               yes | snapcraft promote fluffychat --from-channel edge --to-channel stable
           fi
+
+  deploy_docker:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v4
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This adds a new job to the release pipeline that builds and publishes the Docker image to the GitHub container registry. Example of it running in my fork: https://github.com/jgkawell/fluffychat/pkgs/container/fluffychat

This will help all of us who run the web version in Docker so that we can simply update the tag on our deployment manifest and grab the latest.