### PR TITLE
Fix swapped icons for mark read/unread and pin/unpin

### DIFF
--- a/lib/pages/chat_list/chat_list_header.dart
+++ b/lib/pages/chat_list/chat_list_header.dart
@@ -138,8 +138,8 @@ class ChatListHeader extends StatelessWidget implements PreferredSizeWidget {
                     tooltip: L10n.of(context)!.toggleUnread,
                     icon: Icon(
                       controller.anySelectedRoomNotMarkedUnread
-                          ? Icons.mark_chat_read_outlined
-                          : Icons.mark_chat_unread_outlined,
+                          ? Icons.mark_chat_unread_outlined
+                          : Icons.mark_chat_read_outlined,
                     ),
                     onPressed: controller.toggleUnread,
                   ),

--- a/lib/pages/chat_list/chat_list_header.dart
+++ b/lib/pages/chat_list/chat_list_header.dart
@@ -147,8 +147,8 @@ class ChatListHeader extends StatelessWidget implements PreferredSizeWidget {
                     tooltip: L10n.of(context)!.toggleFavorite,
                     icon: Icon(
                       controller.anySelectedRoomNotFavorite
-                          ? Icons.push_pin_outlined
-                          : Icons.push_pin,
+                          ? Icons.push_pin
+                          : Icons.push_pin_outlined,
                     ),
                     onPressed: controller.toggleFavouriteRoom,
                   ),


### PR DESCRIPTION
If any selected room is not marked unread
(anySelectedRoomNotMarkedUnread), then show the 'mark unread' action
icon, else show the 'mark as read' icon.

This makes it consistent with the notification on/off action.

Similarly to the read/unread toggle this was also using the wrong icon.

If any selected room is not favourite, then show the pin icon (which
should represent the "mark as favourite" action as it corresponds to the
filled pin shown next to a favourited room. Otherwise show the outline
icon, representing the "unpin" action.