### PR TITLE
fix: properly initialize hideUnimportantStateEvents setting

### DIFF
--- a/lib/widgets/matrix.dart
+++ b/lib/widgets/matrix.dart
@@ -423,6 +423,10 @@ class MatrixState extends State<Matrix> with WidgetsBindingObserver {
         store.getBool(SettingKeys.hideUnknownEvents) ??
             AppConfig.hideUnknownEvents;
 
+    AppConfig.hideUnimportantStateEvents =
+        store.getBool(SettingKeys.hideUnimportantStateEvents) ??
+            AppConfig.hideUnimportantStateEvents;
+
     AppConfig.separateChatTypes =
         store.getBool(SettingKeys.separateChatTypes) ??
             AppConfig.separateChatTypes;


### PR DESCRIPTION
This setting was not applied on app restart but always initialized to the default value. The only way change this was to go into settings and change the toggle twice after an app restart.