### PR TITLE
feat: make showing user presence info optional

### DIFF
--- a/assets/l10n/intl_en.arb
+++ b/assets/l10n/intl_en.arb
@@ -1734,6 +1734,16 @@
         "type": "text",
         "placeholders": {}
     },
+    "presenceStyle": "Presence:",
+    "@presenceStyle": {
+        "type": "text",
+        "placeholders": {}
+    },
+    "presencesToggle": "Show status messages from other users",
+    "@presencesToggle": {
+        "type": "text",
+        "placeholders": {}
+    },
     "singlesignon": "Single Sign on",
     "@singlesignon": {
         "type": "text",

--- a/assets/l10n/intl_en.arb
+++ b/assets/l10n/intl_en.arb
@@ -2300,6 +2300,7 @@
         }
     },
     "hideUnimportantStateEvents": "Hide unimportant state events",
+    "hidePresences": "Hide Status List?",
     "doNotShowAgain": "Do not show again",
     "wasDirectChatDisplayName": "Empty chat (was {oldDisplayName})",
     "@wasDirectChatDisplayName": {

--- a/lib/config/app_config.dart
+++ b/lib/config/app_config.dart
@@ -49,6 +49,7 @@ abstract class AppConfig {
   static bool sendTypingNotifications = true;
   static bool sendPublicReadReceipts = true;
   static bool? sendOnEnter;
+  static bool showPresences = true;
   static bool experimentalVoip = false;
   static const bool hideTypingUsernames = false;
   static const bool hideAllStateEvents = false;

--- a/lib/config/setting_keys.dart
+++ b/lib/config/setting_keys.dart
@@ -28,4 +28,5 @@ abstract class SettingKeys {
       'chat.fluffy.send_public_read_receipts';
   static const String sendOnEnter = 'chat.fluffy.send_on_enter';
   static const String experimentalVoip = 'chat.fluffy.experimental_voip';
+  static const String showPresences = 'chat.fluffy.show_presences';
 }

--- a/lib/pages/chat_list/chat_list.dart
+++ b/lib/pages/chat_list/chat_list.dart
@@ -21,6 +21,7 @@ import 'package:fluffychat/utils/localized_exception_extension.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/matrix_locals.dart';
 import 'package:fluffychat/utils/platform_infos.dart';
 import '../../../utils/account_bundles.dart';
+import '../../config/setting_keys.dart';
 import '../../utils/matrix_sdk_extensions/matrix_file_extension.dart';
 import '../../utils/url_launcher.dart';
 import '../../utils/voip/callkeep_manager.dart';
@@ -509,6 +510,18 @@ class ChatListController extends State<ChatList>
       future: () => _archiveSelectedRooms(),
     );
     setState(() {});
+  }
+
+  void dismissStatusList() async {
+    final result = await showOkCancelAlertDialog(
+      title: L10n.of(context)!.hidePresences,
+      context: context,
+    );
+    if (result == OkCancelResult.ok) {
+      await Matrix.of(context).store.setBool(SettingKeys.showPresences, false);
+      AppConfig.showPresences = false;
+      setState(() {});
+    }
   }
 
   void setStatus() async {

--- a/lib/pages/chat_list/chat_list_body.dart
+++ b/lib/pages/chat_list/chat_list_body.dart
@@ -5,6 +5,7 @@ import 'package:animations/animations.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
 import 'package:matrix/matrix.dart';
 
+import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/pages/chat_list/chat_list.dart';
 import 'package:fluffychat/pages/chat_list/chat_list_item.dart';
 import 'package:fluffychat/pages/chat_list/search_title.dart';
@@ -131,7 +132,8 @@ class ChatListViewBody extends StatelessWidget {
                         ),
                       ],
                       if (!controller.isSearchMode &&
-                          controller.activeFilter != ActiveFilter.groups)
+                          controller.activeFilter != ActiveFilter.groups &&
+                          AppConfig.showPresences)
                         StatusMessageList(
                           onStatusEdit: controller.setStatus,
                         ),

--- a/lib/pages/chat_list/chat_list_body.dart
+++ b/lib/pages/chat_list/chat_list_body.dart
@@ -134,8 +134,11 @@ class ChatListViewBody extends StatelessWidget {
                       if (!controller.isSearchMode &&
                           controller.activeFilter != ActiveFilter.groups &&
                           AppConfig.showPresences)
-                        StatusMessageList(
-                          onStatusEdit: controller.setStatus,
+                        GestureDetector(
+                          onLongPress: () => controller.dismissStatusList(),
+                          child: StatusMessageList(
+                            onStatusEdit: controller.setStatus,
+                          ),
                         ),
                       const ConnectionStatusHeader(),
                       AnimatedContainer(

--- a/lib/pages/settings_style/settings_style_view.dart
+++ b/lib/pages/settings_style/settings_style_view.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import 'package:flutter_gen/gen_l10n/l10n.dart';
 
+import 'package:fluffychat/config/setting_keys.dart';
 import 'package:fluffychat/config/themes.dart';
 import 'package:fluffychat/utils/account_config.dart';
 import 'package:fluffychat/widgets/avatar.dart';
@@ -9,6 +10,7 @@ import 'package:fluffychat/widgets/layouts/max_width_body.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 import 'package:fluffychat/widgets/mxc_image.dart';
 import '../../config/app_config.dart';
+import '../../widgets/settings_switch_list_tile.dart';
 import 'settings_style.dart';
 
 class SettingsStyleView extends StatelessWidget {
@@ -160,6 +162,22 @@ class SettingsStyleView extends StatelessWidget {
               value: ThemeMode.dark,
               title: Text(L10n.of(context)!.darkTheme),
               onChanged: controller.switchTheme,
+            ),
+            const Divider(height: 1),
+            ListTile(
+              title: Text(
+                L10n.of(context)!.presenceStyle,
+                style: TextStyle(
+                  color: Theme.of(context).colorScheme.secondary,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ),
+            SettingsSwitchListTile.adaptive(
+              title: L10n.of(context)!.presencesToggle,
+              onChanged: (b) => AppConfig.showPresences = b,
+              storeKey: SettingKeys.showPresences,
+              defaultValue: AppConfig.showPresences,
             ),
             const Divider(height: 1),
             ListTile(

--- a/lib/widgets/matrix.dart
+++ b/lib/widgets/matrix.dart
@@ -62,6 +62,7 @@ class Matrix extends StatefulWidget {
 class MatrixState extends State<Matrix> with WidgetsBindingObserver {
   int _activeClient = -1;
   String? activeBundle;
+
   SharedPreferences get store => widget.store;
 
   HomeserverSummary? loginHomeserverSummary;
@@ -443,6 +444,9 @@ class MatrixState extends State<Matrix> with WidgetsBindingObserver {
 
     AppConfig.experimentalVoip = store.getBool(SettingKeys.experimentalVoip) ??
         AppConfig.experimentalVoip;
+
+    AppConfig.showPresences =
+        store.getBool(SettingKeys.showPresences) ?? AppConfig.showPresences;
   }
 
   @override


### PR DESCRIPTION
895de76e70466616d1baa45f21fa0a3fdeb30ec7 replaced the stories feature with presence status messages. Stories were an optional feature but right now presence information can only be disabled on a homeserver level.

Introduce a setting to make this feature optional on a client level.