### PR TITLE
Add settings to keep images aspect ratio

### DIFF
--- a/assets/l10n/intl_en.arb
+++ b/assets/l10n/intl_en.arb
@@ -154,6 +154,11 @@
         "type": "text",
         "placeholder": {}
     },
+    "keepImageAspectRatio": "Keep image aspect ratio",
+    "@keepImageAspectRatio": {
+        "type": "text",
+        "placeholder": {}
+    },
     "badServerLoginTypesException": "The homeserver supports the login types:\n{serverVersions}\nBut this app supports only:\n{supportedVersions}",
     "@badServerLoginTypesException": {
         "type": "text",

--- a/lib/config/app_config.dart
+++ b/lib/config/app_config.dart
@@ -46,6 +46,7 @@ abstract class AppConfig {
   static bool hideUnimportantStateEvents = true;
   static bool separateChatTypes = false;
   static bool autoplayImages = true;
+  static bool keepImageAspectRatio = false;
   static bool sendTypingNotifications = true;
   static bool sendPublicReadReceipts = true;
   static bool? sendOnEnter;

--- a/lib/config/setting_keys.dart
+++ b/lib/config/setting_keys.dart
@@ -22,6 +22,8 @@ abstract class SettingKeys {
   static const String dontAskForBootstrapKey =
       'chat.fluffychat.dont_ask_bootstrap';
   static const String autoplayImages = 'chat.fluffy.autoplay_images';
+  static const String keepImageAspectRatio =
+      'chat.fluffy.keep_image_aspect_ratio';
   static const String sendTypingNotifications =
       'chat.fluffy.send_typing_notifications';
   static const String sendPublicReadReceipts =

--- a/lib/pages/chat/events/message_content.dart
+++ b/lib/pages/chat/events/message_content.dart
@@ -110,11 +110,13 @@ class MessageContent extends StatelessWidget {
       case EventTypes.Sticker:
         switch (event.messageType) {
           case MessageTypes.Image:
+            final fit =
+                AppConfig.keepImageAspectRatio ? BoxFit.contain : BoxFit.cover;
             return ImageBubble(
               event,
               width: 400,
               height: 300,
-              fit: BoxFit.cover,
+              fit: fit,
               borderRadius: borderRadius,
             );
           case MessageTypes.Sticker:

--- a/lib/pages/settings_chat/settings_chat_view.dart
+++ b/lib/pages/settings_chat/settings_chat_view.dart
@@ -64,6 +64,12 @@ class SettingsChatView extends StatelessWidget {
                   storeKey: SettingKeys.autoplayImages,
                   defaultValue: AppConfig.autoplayImages,
                 ),
+              SettingsSwitchListTile.adaptive(
+                title: L10n.of(context)!.keepImageAspectRatio,
+                onChanged: (b) => AppConfig.keepImageAspectRatio = b,
+                storeKey: SettingKeys.keepImageAspectRatio,
+                defaultValue: AppConfig.keepImageAspectRatio,
+              ),
               const Divider(),
               SettingsSwitchListTile.adaptive(
                 title: L10n.of(context)!.sendOnEnter,


### PR DESCRIPTION
This PR add a settings to force images to keep their initial aspect ratio in chat.