### PR TITLE
Fix send on enter

### DIFF
--- a/lib/config/app_config.dart
+++ b/lib/config/app_config.dart
@@ -48,7 +48,7 @@ abstract class AppConfig {
   static bool autoplayImages = true;
   static bool sendTypingNotifications = true;
   static bool sendPublicReadReceipts = true;
-  static bool? sendOnEnter;
+  static bool sendOnEnter = false;
   static bool showPresences = true;
   static bool experimentalVoip = false;
   static const bool hideTypingUsernames = false;

--- a/lib/pages/chat/chat_input_row.dart
+++ b/lib/pages/chat/chat_input_row.dart
@@ -236,7 +236,7 @@ class ChatInputRow extends StatelessWidget {
                     autofocus: !PlatformInfos.isMobile,
                     keyboardType: TextInputType.multiline,
                     textInputAction:
-                        AppConfig.sendOnEnter == true && PlatformInfos.isMobile
+                        AppConfig.sendOnEnter == true && !PlatformInfos.isMobile
                             ? TextInputAction.send
                             : null,
                     onSubmitted: controller.onInputBarSubmitted,


### PR DESCRIPTION
This PR aims to fix the fact that send on enter is not working as expected at least on desktop. The issue seems to come from the fact that the settings is null by default, but turned on in the settings.

By providing a default value, this issue should be prevented.