### PR TITLE
Point to correct path for auth.html so completing sso login flow no longer 404s

### DIFF
--- a/lib/pages/homeserver_picker/homeserver_picker.dart
+++ b/lib/pages/homeserver_picker/homeserver_picker.dart
@@ -117,7 +117,7 @@ class HomeserverPickerController extends State<HomeserverPicker> {
 
   void ssoLoginAction(String? id) async {
     final redirectUrl = kIsWeb
-        ? '${html.window.origin!}/web/auth.html'
+        ? '${html.window.origin!}/auth.html'
         : isDefaultPlatform
             ? '${AppConfig.appOpenUrlScheme.toLowerCase()}://login'
             : 'http://localhost:3001//login';


### PR DESCRIPTION
The path is just /auth.html in the docker image, not sure if its a different path for other installation methods