### PR TITLE
fix: never use root navigator for bottom sheets

### DIFF
--- a/lib/utils/adaptive_bottom_sheet.dart
+++ b/lib/utils/adaptive_bottom_sheet.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 
 import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/config/themes.dart';
-import 'package:fluffychat/utils/platform_infos.dart';
 
 Future<T?> showAdaptiveBottomSheet<T>({
   required BuildContext context,
@@ -14,7 +13,8 @@ Future<T?> showAdaptiveBottomSheet<T>({
     showModalBottomSheet(
       context: context,
       builder: builder,
-      useRootNavigator: !PlatformInfos.isMobile,
+      // this sadly is ugly on desktops but otherwise breaks `.of(context)` calls
+      useRootNavigator: false,
       isDismissible: isDismissible,
       isScrollControlled: isScrollControlled,
       constraints: BoxConstraints(


### PR DESCRIPTION
I realized for a while ago : If I login with a new session to FluffyChat, there always appears the friendly dialog asking me to perform SAS verification or SSSS unlock.

When on Linux, pressing the SAS button always failed. On mobile it worked. Looks like there was accidentally the root navigator used on desktops - and `Matrix.of(context)` (or whatever custom.of(context)) was unavailable in bottom sheets.

This PR fixes this bug by simply also not using the root navigator on desktops - as we already do on mobile. Disadvantage : If the `showModalBottomSheet` function is called from a sub-page on, it is only centered to that page. I guess that's definitely design wise a disadvantage but unless there's a better fix, I'd consider this as acceptable UI regression compared to have UI-wise beautiful sheets that sadly won't work.