### PR TITLE
chore: do not use static openssl

### DIFF
--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -2,6 +2,8 @@
 cmake_minimum_required(VERSION 3.10)
 project(runner LANGUAGES CXX)
 
+# smth sqlcipher_flutter_libs static linking Hundreds
+set(OPENSSL_USE_STATIC_LIBS OFF)
 # The name of the executable created for the application. Change this to change
 # the on-disk name of your application.
 set(BINARY_NAME "fluffychat")

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1799,10 +1799,10 @@ packages:
     dependency: "direct main"
     description:
       name: sqlcipher_flutter_libs
-      sha256: e2d4dde4288c7fd1fd1cc0b1d39a9cf537ec236fed0c6dcd54b577543872a19d
+      sha256: "60fe3444ff5b1b298a9ca3003c6c7f1f7ee4c90aa6035a8647f3aeaf05a073e2"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.0"
+    version: "0.6.1"
   sqlite3:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -83,7 +83,7 @@ dependencies:
   shared_preferences: ^2.2.0 # Pinned because https://github.com/flutter/flutter/issues/118401
   slugify: ^2.0.0
   sqflite_common_ffi: ^2.3.0+4
-  sqlcipher_flutter_libs: ^0.6.0
+  sqlcipher_flutter_libs: ^0.6.1
   swipe_to_action: ^0.2.0
   tor_detector_web: ^1.1.0
   uni_links: ^0.5.1


### PR DESCRIPTION
I close this option, to make it compilable on archlinux.

see the readme
https://github.com/simolus3/sqlite3.dart/blob/main/sqlcipher_flutter_libs/README.md

I do not think the option is needed  on linux machine