### PR TITLE
feat: use dynamic linking for OpenSSL on Linux

### DIFF
--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -13,6 +13,9 @@ set(APPLICATION_ID "chat.fluffy.fluffychat")
 # versions of CMake.
 cmake_policy(SET CMP0063 NEW)
 
+# dynamically link OpenSSL
+set(OPENSSL_USE_STATIC_LIBS OFF)
+
 # Load bundled libraries from the lib/ directory relative to the binary.
 set(CMAKE_INSTALL_RPATH "$ORIGIN/lib")
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1799,10 +1799,10 @@ packages:
     dependency: "direct main"
     description:
       name: sqlcipher_flutter_libs
-      sha256: e2d4dde4288c7fd1fd1cc0b1d39a9cf537ec236fed0c6dcd54b577543872a19d
+      sha256: "60fe3444ff5b1b298a9ca3003c6c7f1f7ee4c90aa6035a8647f3aeaf05a073e2"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.0"
+    version: "0.6.1"
   sqlite3:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -83,7 +83,7 @@ dependencies:
   shared_preferences: ^2.2.0 # Pinned because https://github.com/flutter/flutter/issues/118401
   slugify: ^2.0.0
   sqflite_common_ffi: ^2.3.0+4
-  sqlcipher_flutter_libs: ^0.6.0
+  sqlcipher_flutter_libs: ^0.6.1
   swipe_to_action: ^0.2.0
   tor_detector_web: ^1.1.0
   uni_links: ^0.5.1


### PR DESCRIPTION
- dynamically link OpenSSL
- OpenSSL is _really_ preinstalled on any Linux machine
- shrinks the app size on Linux
- drops dependency on an OpenSSL static installation on development machines. This makes packaging for many distributions easier.

Since Version 0.6.1, `package:sqlcipher_flutter_libs` finally supports dynamic linking for OpenSSL. We can finally make use of it.

There is no breaking behavior about this.

Related patches in Arch Linux package upstream :
- https://aur.archlinux.org/cgit/aur.git/tree/openssl-dynamic-link.patch?h=fluffychat
- https://aur.archlinux.org/cgit/aur.git/tree/openssl-dynamic-link.patch?h=fluffychat-git