### PR TITLE
fix: migrate back to Hive on Linux

### DIFF
--- a/lib/utils/client_manager.dart
+++ b/lib/utils/client_manager.dart
@@ -22,6 +22,7 @@ import 'matrix_sdk_extensions/flutter_matrix_dart_sdk_database/builder.dart';
 
 abstract class ClientManager {
   static const String clientNamespace = 'im.fluffychat.store.clients';
+
   static Future<List<Client>> getClients({
     bool initialize = true,
     required SharedPreferences store,
@@ -113,7 +114,11 @@ abstract class ClientManager {
       },
       logLevel: kReleaseMode ? Level.warning : Level.verbose,
       databaseBuilder: flutterMatrixSdkDatabaseBuilder,
-      legacyDatabaseBuilder: FlutterHiveCollectionsDatabase.databaseBuilder,
+      // workaround : migrate back from SQLite to Hive on Linux
+      // Related : https://github.com/krille-chan/fluffychat/issues/972
+      legacyDatabaseBuilder: PlatformInfos.isLinux
+          ? (client) => flutterMatrixSdkDatabaseBuilder(client, isLegacy: true)
+          : FlutterHiveCollectionsDatabase.databaseBuilder,
       supportedLoginTypes: {
         AuthenticationTypes.password,
         AuthenticationTypes.sso,


### PR DESCRIPTION
Such sweet sorrow ...

Sadly sqlcipher highly struggles with sigkill. In case FluffyChat receives a sigkill while there's an ongoing database operation, the database in every case corrupts.

Since I didn't find a canonical way to recover this, I'd propose to temporarily migrate back to Hive on Linux - until we reached at fixing the upstream of the Flutter sqlcipher wrapper. I think both @selfisekai and me went deeper into that but as of now we keep crashing when using the distributed sqlcipher from the platform packages rather than the bundled and honestly weirdly implemented sqlcipher distributed in the Flutter wrapper.

Once we fix the upstream, we can likely remove this fix - since it also affects other of my projects I'm sure I'll keep going deeper into it.

So far : best regards from Hive 😢 ...