### PR TITLE
chatlist is laggy, speed a little up

### DIFF
--- a/lib/pages/chat_list/chat_list_item.dart
+++ b/lib/pages/chat_list/chat_list_item.dart
@@ -86,7 +86,7 @@ class ChatListItem extends StatelessWidget {
         borderRadius: BorderRadius.circular(AppConfig.borderRadius),
         clipBehavior: Clip.hardEdge,
         color: backgroundColor,
-        child: FutureBuilder(future: () async {return Future.value(room.hasNewMessages);} (),
+        child: FutureBuilder(future: Future.microtask(() => room.hasNewMessages),
         initialData: false, 
         builder: (context, hasMoreMessage)  {
           final hasNewMessages = hasMoreMessage.data ?? false;


### PR DESCRIPTION
Room.hasNewMessages invoke some heavy CPU function like FromJson (noticed from flutter run -d android --profile, CPU profiler), so using FutureBuilder to wrap it, and the room.isDirectChat will query all rooms which is slow too but it won't change at one render frame so make it as a temporary variable which may help.

> ChatListItem still will cost 80ms sometime, hope it will be solve latter.