### PR TITLE
Fix web prepare script

### DIFF
--- a/scripts/prepare-web.sh
+++ b/scripts/prepare-web.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -ve
-rm -r assets/js/package
+rm assets/js/package/olm*
 
-OLM_VERSION=$(cat pubspec.yaml | yq .dependencies.flutter_olm)
+OLM_VERSION=$(cat pubspec.yaml | yq -r .dependencies.flutter_olm)
 DOWNLOAD_PATH="https://github.com/famedly/olm/releases/download/v$OLM_VERSION/olm.zip"
 
 cd assets/js/ && curl -L $DOWNLOAD_PATH > olm.zip && cd ../../


### PR DESCRIPTION
First `rm` change allows the script to run again.

At least on my system with `yq` v3.4.3 without the raw flag it would output a string with quotes breaking the curl.