### PR TITLE
refactor: Make MatrixState cleaner

### DIFF
--- a/lib/widgets/matrix.dart
+++ b/lib/widgets/matrix.dart
@@ -117,8 +117,8 @@ class MatrixState extends State<Matrix> with WidgetsBindingObserver {
 
   Map<String?, List<Client?>> get accountBundles {
     final resBundles = <String?, List<_AccountBundleWithClient>>{};
-    for (var i = 0; i < widget.clients.length; i++) {
-      final bundles = widget.clients[i].accountBundles;
+    for (Client client in widget.clients) {
+      final bundles = client.accountBundles;
       for (final bundle in bundles) {
         if (bundle.name == null) {
           continue;
@@ -126,7 +126,7 @@ class MatrixState extends State<Matrix> with WidgetsBindingObserver {
         resBundles[bundle.name] ??= [];
         resBundles[bundle.name]!.add(
           _AccountBundleWithClient(
-            client: widget.clients[i],
+            client: client,
             bundle: bundle,
           ),
         );


### PR DESCRIPTION
I think it would've been better if fluffychat's developers had written "foreach"es instead of simple "for"s.