### PR TITLE
feat: add option to configure reply swipe direction

### DIFF
--- a/assets/l10n/intl_en.arb
+++ b/assets/l10n/intl_en.arb
@@ -180,6 +180,8 @@
   },
   "sendTypingNotifications": "Send typing notifications",
   "@sendTypingNotifications": {},
+  "swipeRightToLeftToReply": "Swipe right to left to reply",
+  "@swipeRightToLeftToReply": {},
   "sendOnEnter": "Send on enter",
   "@sendOnEnter": {},
   "badServerVersionsException": "The homeserver supports the Spec versions:\n{serverVersions}\nBut this app supports only {supportedVersions}",

--- a/lib/config/app_config.dart
+++ b/lib/config/app_config.dart
@@ -48,6 +48,7 @@ abstract class AppConfig {
   static bool autoplayImages = true;
   static bool sendTypingNotifications = true;
   static bool sendPublicReadReceipts = true;
+  static bool swipeRightToLeftToReply = true;
   static bool? sendOnEnter;
   static bool showPresences = true;
   static bool experimentalVoip = false;

--- a/lib/config/setting_keys.dart
+++ b/lib/config/setting_keys.dart
@@ -26,6 +26,8 @@ abstract class SettingKeys {
   static const String sendPublicReadReceipts =
       'chat.fluffy.send_public_read_receipts';
   static const String sendOnEnter = 'chat.fluffy.send_on_enter';
+  static const String swipeRightToLeftToReply =
+      'chat.fluffy.swipeRightToLeftToReply';
   static const String experimentalVoip = 'chat.fluffy.experimental_voip';
   static const String showPresences = 'chat.fluffy.show_presences';
   static const String displayChatDetailsColumn =

--- a/lib/pages/chat/events/message.dart
+++ b/lib/pages/chat/events/message.dart
@@ -515,7 +515,9 @@ class Message extends StatelessWidget {
             child: Icon(Icons.check_outlined),
           ),
         ),
-        direction: SwipeDirection.endToStart,
+        direction: AppConfig.swipeRightToLeftToReply
+            ? SwipeDirection.endToStart
+            : SwipeDirection.startToEnd,
         onSwipe: (_) => onSwipe(),
         child: Container(
           constraints: const BoxConstraints(

--- a/lib/pages/settings_chat/settings_chat_view.dart
+++ b/lib/pages/settings_chat/settings_chat_view.dart
@@ -65,6 +65,12 @@ class SettingsChatView extends StatelessWidget {
                 storeKey: SettingKeys.sendOnEnter,
                 defaultValue: AppConfig.sendOnEnter ?? !PlatformInfos.isMobile,
               ),
+              SettingsSwitchListTile.adaptive(
+                title: L10n.of(context)!.swipeRightToLeftToReply,
+                onChanged: (b) => AppConfig.swipeRightToLeftToReply = b,
+                storeKey: SettingKeys.swipeRightToLeftToReply,
+                defaultValue: AppConfig.swipeRightToLeftToReply,
+              ),
               Divider(
                 height: 1,
                 color: Theme.of(context).dividerColor,

--- a/lib/widgets/matrix.dart
+++ b/lib/widgets/matrix.dart
@@ -417,6 +417,10 @@ class MatrixState extends State<Matrix> with WidgetsBindingObserver {
     AppConfig.renderHtml =
         store.getBool(SettingKeys.renderHtml) ?? AppConfig.renderHtml;
 
+    AppConfig.swipeRightToLeftToReply =
+        store.getBool(SettingKeys.swipeRightToLeftToReply) ??
+            AppConfig.swipeRightToLeftToReply;
+
     AppConfig.hideRedactedEvents =
         store.getBool(SettingKeys.hideRedactedEvents) ??
             AppConfig.hideRedactedEvents;


### PR DESCRIPTION
I'd really love there to be an option to reply by swiping from left to right. So I added a small pull request with the corresponding changes.

There is now an option to change the swipe direction in the settings.

:white_check_mark: Tested on Android

Issues that "kinda" reference this: #891 and #957