### PR TITLE
perf: remove unnecessary multidex library

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -47,7 +47,6 @@ android {
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-        multiDexEnabled true
     }
 
     signingConfigs {
@@ -80,9 +79,4 @@ android {
 
 flutter {
     source '../..'
-}
-
-dependencies {
-    //implementation 'com.google.firebase:firebase-messaging:19.0.1' // Workaround for https://github.com/microg/android_packages_apps_GmsCore/issues/313#issuecomment-617651698
-    implementation 'androidx.multidex:multidex:2.0.1'
 }

--- a/android/app/src/main/kotlin/chat/fluffy/fluffychat/MainActivity.kt
+++ b/android/app/src/main/kotlin/chat/fluffy/fluffychat/MainActivity.kt
@@ -4,15 +4,8 @@ import io.flutter.embedding.android.FlutterActivity
 import io.flutter.embedding.engine.FlutterEngine
 
 import android.content.Context
-import androidx.multidex.MultiDex
 
 class MainActivity : FlutterActivity() {
-
-    override fun attachBaseContext(base: Context) {
-        super.attachBaseContext(base)
-        MultiDex.install(this)
-    }
-
 
     override fun provideFlutterEngine(context: Context): FlutterEngine? {
         return provideEngine(this)


### PR DESCRIPTION
Android 5 and up supports multiple dex files natively, there is no need to include the library when minSdkVersion is 21.
https://developer.android.com/build/multidex#mdex-on-l


- [ ] Code formatting and import sorting has been done with `dart format lib/ test/` and `dart run import_sorter:main --no-comments`
- [x] The commit message uses the format of [Conventional Commits](https://www.conventionalcommits.org)
- [ ] The commit message describes what has been changed, why it has been changed and how it has been changed
- [ ] Every new feature or change of the design/GUI is linked to an approved design proposal in an issue
- [ ] Every new feature in the app or the build system has a strategy how this will be tested and maintained from now on for every release, e.g. a volunteer who takes over maintainership


### Pull Request has been tested on:

- [x] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS