### PR TITLE
feat[UP]: Notifications for multiple accounts

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -38,7 +38,8 @@ void main() async {
 
     // In the background fetch mode we do not want to waste ressources with
     // starting the Flutter engine but process incoming push notifications.
-    BackgroundPush.clientOnly(clients.first);
+    BackgroundPush.initInstancesClientsOnly(clients);
+
     // To start the flutter engine afterwards we add an custom observer.
     WidgetsBinding.instance.addObserver(AppStarter(clients, store));
     Logs().i(

--- a/lib/pages/chat/chat.dart
+++ b/lib/pages/chat/chat.dart
@@ -27,15 +27,16 @@ import 'package:fluffychat/pages/chat/chat_view.dart';
 import 'package:fluffychat/pages/chat/event_info_dialog.dart';
 import 'package:fluffychat/pages/chat/recording_dialog.dart';
 import 'package:fluffychat/pages/chat_details/chat_details.dart';
+import 'package:fluffychat/utils/account_bundles.dart';
+import 'package:fluffychat/utils/background_push.dart';
 import 'package:fluffychat/utils/error_reporter.dart';
 import 'package:fluffychat/utils/file_selector.dart';
+import 'package:fluffychat/utils/localized_exception_extension.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/event_extension.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/filtered_timeline_extension.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/matrix_locals.dart';
 import 'package:fluffychat/utils/platform_infos.dart';
 import 'package:fluffychat/widgets/matrix.dart';
-import '../../utils/account_bundles.dart';
-import '../../utils/localized_exception_extension.dart';
 import 'send_file_dialog.dart';
 import 'send_location_dialog.dart';
 
@@ -395,7 +396,10 @@ class ChatController extends State<ChatPageWithRoom>
       _setReadMarkerFuture = null;
     });
     if (eventId == null || eventId == timeline.room.lastEvent?.eventId) {
-      Matrix.of(context).backgroundPush?.cancelNotification(roomId);
+      final clientsInRoom = Matrix.of(context).getClientsInRoom(roomId);
+      for (final c in clientsInRoom) {
+        BackgroundPush.getInstance(c)?.cancelNotification(roomId);
+      }
     }
   }
 

--- a/lib/pages/chat_list/chat_list.dart
+++ b/lib/pages/chat_list/chat_list.dart
@@ -17,21 +17,22 @@ import 'package:receive_sharing_intent/receive_sharing_intent.dart';
 import 'package:uni_links/uni_links.dart';
 
 import 'package:fluffychat/config/app_config.dart';
+import 'package:fluffychat/config/setting_keys.dart';
+import 'package:fluffychat/pages/bootstrap/bootstrap_dialog.dart';
 import 'package:fluffychat/pages/chat/send_file_dialog.dart';
 import 'package:fluffychat/pages/chat_list/chat_list_view.dart';
+import 'package:fluffychat/utils/account_bundles.dart';
+import 'package:fluffychat/utils/background_push.dart';
 import 'package:fluffychat/utils/localized_exception_extension.dart';
+import 'package:fluffychat/utils/matrix_sdk_extensions/matrix_file_extension.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/matrix_locals.dart';
 import 'package:fluffychat/utils/platform_infos.dart';
 import 'package:fluffychat/utils/show_update_snackbar.dart';
+import 'package:fluffychat/utils/url_launcher.dart';
+import 'package:fluffychat/utils/voip/callkeep_manager.dart';
 import 'package:fluffychat/widgets/avatar.dart';
-import '../../../utils/account_bundles.dart';
-import '../../config/setting_keys.dart';
-import '../../utils/matrix_sdk_extensions/matrix_file_extension.dart';
-import '../../utils/url_launcher.dart';
-import '../../utils/voip/callkeep_manager.dart';
-import '../../widgets/fluffy_chat_app.dart';
-import '../../widgets/matrix.dart';
-import '../bootstrap/bootstrap_dialog.dart';
+import 'package:fluffychat/widgets/fluffy_chat_app.dart';
+import 'package:fluffychat/widgets/matrix.dart';
 
 import 'package:fluffychat/utils/tor_stub.dart'
     if (dart.library.html) 'package:tor_detector_web/tor_detector_web.dart';
@@ -519,7 +520,7 @@ class ChatListController extends State<ChatList>
       if (mounted) {
         searchServer =
             Matrix.of(context).store.getString(_serverStoreNamespace);
-        Matrix.of(context).backgroundPush?.setupPush();
+        BackgroundPush.setupPush();
         UpdateNotifier.showUpdateSnackBar(context);
       }
 

--- a/lib/utils/account_config.dart
+++ b/lib/utils/account_config.dart
@@ -1,5 +1,7 @@
 import 'package:matrix/matrix.dart';
 
+import 'package:fluffychat/config/setting_keys.dart';
+
 extension ApplicationAccountConfigExtension on Client {
   static const String accountDataKey = 'im.fluffychat.account_config';
 
@@ -29,6 +31,10 @@ extension ApplicationAccountConfigExtension on Client {
         wallpaperUrl: config.wallpaperUrl ?? currentConfig.wallpaperUrl,
         wallpaperOpacity:
             config.wallpaperOpacity ?? currentConfig.wallpaperOpacity,
+        unifiedPushEndpoint:
+            config.unifiedPushEndpoint ?? currentConfig.unifiedPushEndpoint,
+        unifiedPushRegistered:
+            config.unifiedPushRegistered ?? currentConfig.unifiedPushRegistered,
       ).toJson(),
     );
   }
@@ -37,10 +43,14 @@ extension ApplicationAccountConfigExtension on Client {
 class ApplicationAccountConfig {
   final Uri? wallpaperUrl;
   final double? wallpaperOpacity;
+  final String? unifiedPushEndpoint;
+  final bool? unifiedPushRegistered;
 
   const ApplicationAccountConfig({
     this.wallpaperUrl,
     this.wallpaperOpacity,
+    this.unifiedPushEndpoint,
+    this.unifiedPushRegistered,
   });
 
   static double _sanitizedOpacity(double? opacity) {
@@ -56,10 +66,17 @@ class ApplicationAccountConfig {
             : null,
         wallpaperOpacity:
             _sanitizedOpacity(json.tryGet<double>('wallpaper_opacity')),
+        unifiedPushEndpoint: json[SettingKeys.unifiedPushEndpoint] is String
+            ? json[SettingKeys.unifiedPushEndpoint]
+            : "",
+        unifiedPushRegistered:
+            json.tryGet<bool>(SettingKeys.unifiedPushRegistered),
       );
 
   Map<String, dynamic> toJson() => {
         'wallpaper_url': wallpaperUrl?.toString(),
         'wallpaper_opacity': wallpaperOpacity,
+        SettingKeys.unifiedPushEndpoint: unifiedPushEndpoint,
+        SettingKeys.unifiedPushRegistered: unifiedPushRegistered?.toString(),
       };
 }

--- a/lib/widgets/matrix.dart
+++ b/lib/widgets/matrix.dart
@@ -71,8 +71,6 @@ class MatrixState extends State<Matrix> with WidgetsBindingObserver {
   String? loginUsername;
   bool? loginRegistrationSupported;
 
-  BackgroundPush? backgroundPush;
-
   Client get client {
     if (widget.clients.isEmpty) {
       widget.clients.add(getLoginClient());
@@ -363,8 +361,9 @@ class MatrixState extends State<Matrix> with WidgetsBindingObserver {
     }
 
     if (PlatformInfos.isMobile) {
-      backgroundPush = BackgroundPush(
+      BackgroundPush.initInstances(
         this,
+        widget.clients,
         onFcmError: (errorMsg, {Uri? link}) async {
           final result = await showOkCancelAlertDialog(
             barrierDismissible: true,
@@ -517,6 +516,12 @@ class MatrixState extends State<Matrix> with WidgetsBindingObserver {
 
     final file = MatrixFile(bytes: exportBytes, name: exportFileName);
     file.save(context);
+  }
+
+  List<Client> getClientsInRoom(String id) {
+    return widget.clients.where((client) {
+      return client.getRoomById(id) != null;
+    }).toList();
   }
 }
 


### PR DESCRIPTION
!!This is a WIP!!
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

Please make sure that your Pull Request meet the following **acceptance criteria**:

- [x] Code formatting and import sorting has been done with `dart format lib/ test/` and `dart run import_sorter:main --no-comments`
- [x] The commit message uses the format of [Conventional Commits](https://www.conventionalcommits.org)
- [ ] The commit message describes what has been changed, why it has been changed and how it has been changed
- [ ] Every new feature or change of the design/GUI is linked to an approved design proposal in an issue
- [ ] Every new feature in the app or the build system has a strategy how this will be tested and maintained from now on for every release, e.g. a volunteer who takes over maintainership


### Pull Request has been tested on:

- [x] Android (emulator)
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

I started work on supporting notifications on multiple accounts via UP. I succeeded in creating multiple topics (ntfy) but sadly all of them receive notifications only from the same account and that account only. After a bit of digging it seems like flutter_local_notifications works with singletons as our code did before this PR as well. I suspect this leads to the odd behavior.
Now I have a few questions on how to proceed:
Is there a general interest in this feature?
Implementing this feature could required either implementing support upstream or looking for alternatives. Are there opinions in either direction?
Are my suspicions right in the first place? Am I overlooking something? Is something else causing this behavior I'm not aware of?

Kind regards :)