### PR TITLE
fix: dont use thumbnails for emoticons

### DIFF
--- a/lib/pages/chat/events/html_message.dart
+++ b/lib/pages/chat/events/html_message.dart
@@ -272,14 +272,18 @@ class ImageExtension extends HtmlExtension {
     final width = double.tryParse(context.attributes['width'] ?? '');
     final height = double.tryParse(context.attributes['height'] ?? '');
 
+    final actualWidth = width ?? height ?? defaultDimension;
+    final actualHeight = height ?? width ?? defaultDimension;
+
     return WidgetSpan(
       child: SizedBox(
-        width: width ?? height ?? defaultDimension,
-        height: height ?? width ?? defaultDimension,
+        width: actualWidth,
+        height: actualHeight,
         child: MxcImage(
           uri: mxcUrl,
-          width: width ?? height ?? defaultDimension,
-          height: height ?? width ?? defaultDimension,
+          width: actualWidth,
+          height: actualHeight,
+          isThumbnail: (actualWidth * actualHeight) > (256 * 256),
         ),
       ),
     );

--- a/lib/pages/chat/events/message_reactions.dart
+++ b/lib/pages/chat/events/message_reactions.dart
@@ -122,6 +122,7 @@ class _Reaction extends StatelessWidget {
             width: 20,
             height: 20,
             animated: false,
+            isThumbnail: false,
           ),
           if (count > 1) ...[
             const SizedBox(width: 4),

--- a/lib/pages/chat/input_bar.dart
+++ b/lib/pages/chat/input_bar.dart
@@ -276,6 +276,7 @@ class InputBar extends StatelessWidget {
                   : null,
               width: size,
               height: size,
+              isThumbnail: false,
             ),
             const SizedBox(width: 6),
             Text(suggestion['name']!),

--- a/lib/pages/chat/sticker_picker_dialog.dart
+++ b/lib/pages/chat/sticker_picker_dialog.dart
@@ -92,6 +92,7 @@ class StickerPickerDialogState extends State<StickerPickerDialog> {
                     width: 128,
                     height: 128,
                     animated: true,
+                    isThumbnail: false,
                   ),
                 ),
               );

--- a/lib/pages/settings_emotes/settings_emotes_view.dart
+++ b/lib/pages/settings_emotes/settings_emotes_view.dart
@@ -247,6 +247,7 @@ class _EmoteImage extends StatelessWidget {
         fit: BoxFit.contain,
         width: size,
         height: size,
+        isThumbnail: false,
       ),
     );
   }


### PR DESCRIPTION
In this pull request I went over places where `MxcImage` is used and in case of custom emojis set `isThumbnail` to false, as the thumbnail generation causes emoticons to lose transparency and in some cases overall animations. (more info in #1071)

The only place I'm worried about is `html_message.dart`, where I'm using the following snippet: `isThumbnail: (actualWidth * actualHeight) > (256 * 256)`. Maybe using something the `data-mx-emoticon` property would be more fitting?

Fixes #1071

- [X] Code formatting and import sorting has been done with `dart format lib/ test/` and `dart run import_sorter:main --no-comments`
- [X] The commit message uses the format of [Conventional Commits](https://www.conventionalcommits.org)
- [X] The commit message describes what has been changed, why it has been changed and how it has been changed
- [X] ~~Every new feature or change of the design/GUI is linked to an approved design proposal in an issue~~
- [X] ~~Every new feature in the app or the build system has a strategy how this will be tested and maintained from now on for every release, e.g. a volunteer who takes over maintainership~~


### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [X] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS