### PR TITLE
fix: LoadingSnackBar consistently remains visible until the upload is complete

### DIFF
--- a/lib/pages/chat/send_file_dialog.dart
+++ b/lib/pages/chat/send_file_dialog.dart
@@ -88,10 +88,7 @@ class SendFileDialogState extends State<SendFileDialog> {
               widget.files.length,
             ),
           );
-        } else {
-          scaffoldMessenger.clearSnackBars();
         }
-
         try {
           await widget.room.sendFileEvent(
             file,


### PR DESCRIPTION
- Adjusted the `SendFileDialogState` file to ensure that the `showLoadingSnackBar` remains visible throughout the file upload process.
- the SnackBar is cleared only after the image/file is uploaded and displayed in the chat.

*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

Please make sure that your Pull Request meet the following **acceptance criteria**:

- [x] Code formatting and import sorting has been done with `dart format lib/ test/` and `dart run import_sorter:main --no-comments`
- [x] The commit message uses the format of [Conventional Commits](https://www.conventionalcommits.org)
- [x] The commit message describes what has been changed, why it has been changed and how it has been changed
- [ ] Every new feature or change of the design/GUI is linked to an approved design proposal in an issue
- [ ] Every new feature in the app or the build system has a strategy how this will be tested and maintained from now on for every release, e.g. a volunteer who takes over maintainership


### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [x] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS