### PR TITLE
fix: Pictures in portrait orientation are being sent flipped (in horizontal)

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,6 +8,8 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
+  exif: ^3.1.4
+  image: ^4.0.17
   animations: ^2.0.11
   archive: ^3.4.10
   async: ^2.11.0


### PR DESCRIPTION
- [x] Code formatting and import sorting has been done with `dart format lib/ test/` and `dart run import_sorter:main --no-comments`
- [x] The commit message uses the format of [Conventional Commits](https://www.conventionalcommits.org)
- [x] The commit message describes what has been changed, why it has been changed and how it has been changed
- [x] Every new feature or change of the design/GUI is linked to an approved design proposal in an issue
- [x] Every new feature in the app or the build system has a strategy how this will be tested and maintained from now on for every release, e.g. a volunteer who takes over maintainership


### Pull Request has been tested on:

- [x] Android

###Approach:
To resolve this issue, the image data needs to be adjusted according to its EXIF orientation before being displayed. By reading the EXIF metadata from the image and applying the necessary transformations (rotations and flips), we can ensure that images are displayed with the correct orientation.
