### PR TITLE
fix: prevent users from creating group chats or spaces with empty names

### DIFF
--- a/lib/pages/new_group/new_group.dart
+++ b/lib/pages/new_group/new_group.dart
@@ -2,6 +2,7 @@ import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
 
+import 'package:flutter_gen/gen_l10n/l10n.dart';
 import 'package:go_router/go_router.dart';
 import 'package:matrix/matrix.dart' as sdk;
 import 'package:matrix/matrix.dart';
@@ -112,6 +113,12 @@ class NewGroupController extends State<NewGroup> {
     final client = Matrix.of(context).client;
 
     try {
+      if (nameController.text.trim().isEmpty &&
+          createGroupType == CreateGroupType.space) {
+        setState(() => error = L10n.of(context).pleaseFillOut);
+        return;
+      }
+
       setState(() {
         loading = true;
         error = null;


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

Please make sure that your Pull Request meet the following **acceptance criteria**:

- [x] Code formatting and import sorting has been done with `dart format lib/ test/` and `dart run import_sorter:main --no-comments`
- [x] The commit message uses the format of [Conventional Commits](https://www.conventionalcommits.org)
- [x] The commit message describes what has been changed, why it has been changed and how it has been changed
- [ ] Every new feature or change of the design/GUI is linked to an approved design proposal in an issue
- [ ] Every new feature in the app or the build system has a strategy how this will be tested and maintained from now on for every release, e.g. a volunteer who takes over maintainership


### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [x] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

Hello! This PR is related to issue #1602 
I'm not sure if the option to create rooms without names is there on purpose (if it is, please let me know), but it can be a confusing user experience. This PR prevents users from creating rooms with empty names and gives them a warning message when they try to do so.