### PR TITLE
fix: ordered list showing wrong number sequence in html rendering

### DIFF
--- a/lib/pages/chat/events/html_message.dart
+++ b/lib/pages/chat/events/html_message.dart
@@ -415,12 +415,36 @@ class HtmlMessage extends StatelessWidget {
             'strikethrough' =>
               const TextStyle(decoration: TextDecoration.lineThrough),
             'u' => const TextStyle(decoration: TextDecoration.underline),
-            'h1' => TextStyle(fontSize: fontSize * 1.6, height: 2),
-            'h2' => TextStyle(fontSize: fontSize * 1.5, height: 2),
-            'h3' => TextStyle(fontSize: fontSize * 1.4, height: 2),
-            'h4' => TextStyle(fontSize: fontSize * 1.3, height: 1.75),
-            'h5' => TextStyle(fontSize: fontSize * 1.2, height: 1.75),
-            'h6' => TextStyle(fontSize: fontSize * 1.1, height: 1.5),
+            'h1' => TextStyle(
+                fontSize: fontSize * 1.6,
+                height: 2,
+                fontWeight: FontWeight.w700,
+              ),
+            'h2' => TextStyle(
+                fontSize: fontSize * 1.5,
+                height: 2,
+                fontWeight: FontWeight.w700,
+              ),
+            'h3' => TextStyle(
+                fontSize: fontSize * 1.4,
+                height: 2,
+                fontWeight: FontWeight.w700,
+              ),
+            'h4' => TextStyle(
+                fontSize: fontSize * 1.3,
+                height: 1.75,
+                fontWeight: FontWeight.w700,
+              ),
+            'h5' => TextStyle(
+                fontSize: fontSize * 1.2,
+                height: 1.75,
+                fontWeight: FontWeight.w700,
+              ),
+            'h6' => TextStyle(
+                fontSize: fontSize * 1.1,
+                height: 1.5,
+                fontWeight: FontWeight.w700,
+              ),
             'span' => TextStyle(
                 color: node.attributes['color']?.hexToColor ??
                     node.attributes['data-mx-color']?.hexToColor ??

--- a/lib/pages/chat/events/html_message.dart
+++ b/lib/pages/chat/events/html_message.dart
@@ -228,7 +228,7 @@ class HtmlMessage extends StatelessWidget {
                   if (node.parent?.localName == 'ol')
                     TextSpan(
                       text:
-                          '${(node.parent?.nodes.indexOf(node) ?? 0) + (int.tryParse(node.parent?.attributes['start'] ?? '1') ?? 1)}. ',
+                          '${(node.parent?.nodes.where((node) => node.nodeType == dom.Node.ELEMENT_NODE).toList().indexOf(node) ?? 0) + (int.tryParse(node.parent?.attributes['start'] ?? '1') ?? 1)}. ',
                     ),
                   ..._renderWithLineBreaks(
                     node.nodes,


### PR DESCRIPTION
The `nodes` for the ordered list sometimes contain `Text` elements with the string " " which make the sequence numbers displayed wrong. This PR fixes that and also a small styling issue for heading tags (they're supposed to have w700 weight).

Please make sure that your Pull Request meet the following **acceptance criteria**:

- [x] Code formatting and import sorting has been done with `dart format lib/ test/` and `dart run import_sorter:main --no-comments`
- [x] The commit message uses the format of [Conventional Commits](https://www.conventionalcommits.org)
- [x] The commit message describes what has been changed, why it has been changed and how it has been changed
- [x] Every new feature or change of the design/GUI is linked to an approved design proposal in an issue
- [x] Every new feature in the app or the build system has a strategy how this will be tested and maintained from now on for every release, e.g. a volunteer who takes over maintainership


### Pull Request has been tested on:

- [x] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS