### PR TITLE
fix: update condition in account deletion function to prevent early return

### DIFF
--- a/lib/pages/settings_security/settings_security.dart
+++ b/lib/pages/settings_security/settings_security.dart
@@ -61,7 +61,7 @@ class SettingsSecurityController extends State<SettingsSecurity> {
       return;
     }
     final supposedMxid = Matrix.of(context).client.userID!;
-    final mxids = await showTextInputDialog(
+    final mxid = await showTextInputDialog(
       useRootNavigator: false,
       context: context,
       title: L10n.of(context).confirmMatrixId,
@@ -72,7 +72,7 @@ class SettingsSecurityController extends State<SettingsSecurity> {
       okLabel: L10n.of(context).delete,
       cancelLabel: L10n.of(context).cancel,
     );
-    if (mxids == null || mxids.length != 1 || mxids != supposedMxid) {
+    if (mxid == null || mxid.isEmpty || mxid != supposedMxid) {
       return;
     }
     final input = await showTextInputDialog(


### PR DESCRIPTION
Hello! The current check for ```mxids.length != 1``` prevents account deletion from going through (I think this is left over from before the switch away from the adaptive_dialog package). I replaced this with a check for an empty string.

*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

Please make sure that your Pull Request meet the following **acceptance criteria**:

- [x] Code formatting and import sorting has been done with `dart format lib/ test/` and `dart run import_sorter:main --no-comments`
- [x] The commit message uses the format of [Conventional Commits](https://www.conventionalcommits.org)
- [x] The commit message describes what has been changed, why it has been changed and how it has been changed
- [ ] Every new feature or change of the design/GUI is linked to an approved design proposal in an issue
- [ ] Every new feature in the app or the build system has a strategy how this will be tested and maintained from now on for every release, e.g. a volunteer who takes over maintainership


### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [x] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS