### PR TITLE
feat: Experimental URL preview

### DIFF
--- a/lib/utils/file_description.dart
+++ b/lib/utils/file_description.dart
@@ -2,6 +2,9 @@ import 'package:matrix/matrix.dart';
 
 extension FileDescriptionExtension on Event {
   String? get fileDescription {
+    final description = content.tryGet<String>('description');
+    if (description != null) return description;
+
     if (!{
       MessageTypes.File,
       MessageTypes.Image,


### PR DESCRIPTION
This PR demonstrates a possible (minimal) implementation for the URL previews #18. For regular text messages, when the feature detects a URL, it fetches the preview using the v1 preview_url endpoint. Only the first URL in the message is previewed. `ImageBubble` is utilized for the previews, with a slightly hacky way of filling the `Event` content in order to use it.

Currently, the feature is not complete yet. Completion depends on general interest (and whether this approach is proper at all).

- [ ] There is no way to disable the feature for this demo. Generally, the URL preview should be disabled by default for privacy reasons, with a settings menu option to enable it if desired.
- [ ] Some fallback checks are needed
- [ ] `ImageBubble` description is used for the message caption, which currently does not handle proper style related formatting for the link itself (although it is readable)

Please make sure that your Pull Request meet the following acceptance criteria:

- [x] Code formatting and import sorting has been done with `dart format lib/ test/` and `dart run import_sorter:main --no-comments`
- [x] The commit message uses the format of [Conventional Commits](https://www.conventionalcommits.org)
- [x] The commit message describes what has been changed, why it has been changed and how it has been changed
- [ ] Every new feature or change of the design/GUI is linked to an approved design proposal in an issue
- [x] Every new feature in the app or the build system has a strategy how this will be tested and maintained from now on for every release, e.g. a volunteer who takes over maintainership


### Pull Request has been tested on:

- [x] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [x] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS