### PR TITLE
Make more file-types visible when selecting images or videos to send

### DIFF
--- a/lib/utils/file_selector.dart
+++ b/lib/utils/file_selector.dart
@@ -93,6 +93,10 @@ enum FileSelectorType {
         extensions: <String>['mp4', 'MP4'],
       ),
       XTypeGroup(
+        label: 'WebM',
+        extensions: <String>['webm', 'WebM', 'WEBM'],
+      ),
+      XTypeGroup(
         label: 'AVI',
         extensions: <String>['avi', 'AVI'],
       ),

--- a/lib/utils/file_selector.dart
+++ b/lib/utils/file_selector.dart
@@ -30,17 +30,11 @@ Future<List<XFile>> selectFiles(
 
   if (allowMultiple) {
     return await AppLock.of(context).pauseWhile(
-      openFiles(
-        confirmButtonText: title,
-        acceptedTypeGroups: type.groups,
-      ),
+      openFiles(confirmButtonText: title, acceptedTypeGroups: type.groups),
     );
   }
   final file = await AppLock.of(context).pauseWhile(
-    openFile(
-      confirmButtonText: title,
-      acceptedTypeGroups: type.groups,
-    ),
+    openFile(confirmButtonText: title, acceptedTypeGroups: type.groups),
   );
   if (file == null) return [];
   return [file];
@@ -52,40 +46,44 @@ enum FileSelectorType {
     [
       XTypeGroup(
         label: 'Images',
-        extensions: <String>['jpg', 'JPG', 'jpeg', 'JPEG', 'png', 'PNG', 'webp', 'WebP', 'WEBP', 'gif', 'GIF', 'bmp', 'BMP', 'tiff', 'TIFF', 'tif', 'TIF', 'heic', 'HEIC', 'svg', 'SVG'],
+        extensions: <String>[
+          'jpg',
+          'JPG',
+          'jpeg',
+          'JPEG',
+          'png',
+          'PNG',
+          'webp',
+          'WebP',
+          'WEBP',
+          'gif',
+          'GIF',
+          'bmp',
+          'BMP',
+          'tiff',
+          'TIFF',
+          'tif',
+          'TIF',
+          'heic',
+          'HEIC',
+          'svg',
+          'SVG',
+        ],
       ),
       XTypeGroup(
         label: 'JPG',
         extensions: <String>['jpg', 'JPG', 'jpeg', 'JPEG'],
       ),
-      XTypeGroup(
-        label: 'PNG',
-        extensions: <String>['png', 'PNG'],
-      ),
-      XTypeGroup(
-        label: 'WebP',
-        extensions: <String>['webp', 'WebP', 'WEBP'],
-      ),
-      XTypeGroup(
-        label: 'GIF',
-        extensions: <String>['gif', 'GIF'],
-      ),
-      XTypeGroup(
-        label: 'BMP',
-        extensions: <String>['bmp', 'BMP'],
-      ),
+      XTypeGroup(label: 'PNG', extensions: <String>['png', 'PNG']),
+      XTypeGroup(label: 'WebP', extensions: <String>['webp', 'WebP', 'WEBP']),
+      XTypeGroup(label: 'GIF', extensions: <String>['gif', 'GIF']),
+      XTypeGroup(label: 'BMP', extensions: <String>['bmp', 'BMP']),
       XTypeGroup(
         label: 'TIFF',
         extensions: <String>['tiff', 'TIFF', 'tif', 'TIF'],
       ),
-      XTypeGroup(
-        label: 'HEIC',
-        extensions: <String>['heic', 'HEIC'],
-      ),
-      XTypeGroup(
-        label: 'SVG',
-        extensions: <String>['svg', 'SVG'],
-      ),
+      XTypeGroup(label: 'HEIC', extensions: <String>['heic', 'HEIC']),
+      XTypeGroup(label: 'SVG', extensions: <String>['svg', 'SVG']),
     ],
     FileType.image,
     null,
@@ -94,58 +92,47 @@ enum FileSelectorType {
     [
       XTypeGroup(
         label: 'Videos',
-        extensions: <String>['mp4', 'MP4', 'avi', 'AVI', 'webm', 'WebM', 'WEBM', 'mov', 'MOV', 'mkv', 'MKV', 'wmv', 'WMV', 'flv', 'FLV', 'mpeg', 'MPEG', '3gp', '3GP', 'ogg', 'OGG'],
+        extensions: <String>[
+          'mp4',
+          'MP4',
+          'avi',
+          'AVI',
+          'webm',
+          'WebM',
+          'WEBM',
+          'mov',
+          'MOV',
+          'mkv',
+          'MKV',
+          'wmv',
+          'WMV',
+          'flv',
+          'FLV',
+          'mpeg',
+          'MPEG',
+          '3gp',
+          '3GP',
+          'ogg',
+          'OGG',
+        ],
       ),
-      XTypeGroup(
-        label: 'MP4',
-        extensions: <String>['mp4', 'MP4'],
-      ),
-      XTypeGroup(
-        label: 'WebM',
-        extensions: <String>['webm', 'WebM', 'WEBM'],
-      ),
-      XTypeGroup(
-        label: 'AVI',
-        extensions: <String>['avi', 'AVI'],
-      ),
-      XTypeGroup(
-        label: 'MOV',
-        extensions: <String>['mov', 'MOV'],
-      ),
-      XTypeGroup(
-        label: 'MKV',
-        extensions: <String>['mkv', 'MKV'],
-      ),
-      XTypeGroup(
-        label: 'WMV',
-        extensions: <String>['wmv', 'WMV'],
-      ),
-      XTypeGroup(
-        label: 'FLV',
-        extensions: <String>['flv', 'FLV'],
-      ),
-      XTypeGroup(
-        label: 'MPEG',
-        extensions: <String>['mpeg', 'MPEG'],
-      ),
-      XTypeGroup(
-        label: '3GP',
-        extensions: <String>['3gp', '3GP'],
-      ),
-      XTypeGroup(
-        label: 'OGG',
-        extensions: <String>['ogg', 'OGG'],
-      ),
+      XTypeGroup(label: 'MP4', extensions: <String>['mp4', 'MP4']),
+      XTypeGroup(label: 'WebM', extensions: <String>['webm', 'WebM', 'WEBM']),
+      XTypeGroup(label: 'AVI', extensions: <String>['avi', 'AVI']),
+      XTypeGroup(label: 'MOV', extensions: <String>['mov', 'MOV']),
+      XTypeGroup(label: 'MKV', extensions: <String>['mkv', 'MKV']),
+      XTypeGroup(label: 'WMV', extensions: <String>['wmv', 'WMV']),
+      XTypeGroup(label: 'FLV', extensions: <String>['flv', 'FLV']),
+      XTypeGroup(label: 'MPEG', extensions: <String>['mpeg', 'MPEG']),
+      XTypeGroup(label: '3GP', extensions: <String>['3gp', '3GP']),
+      XTypeGroup(label: 'OGG', extensions: <String>['ogg', 'OGG']),
     ],
     FileType.video,
     null,
   ),
   zip(
     [
-      XTypeGroup(
-        label: 'ZIP',
-        extensions: <String>['zip', 'ZIP'],
-      ),
+      XTypeGroup(label: 'ZIP', extensions: <String>['zip', 'ZIP']),
     ],
     FileType.custom,
     ['zip', 'ZIP'],

--- a/lib/utils/file_selector.dart
+++ b/lib/utils/file_selector.dart
@@ -59,7 +59,7 @@ enum FileSelectorType {
         extensions: <String>['jpg', 'JPG', 'jpeg', 'JPEG'],
       ),
       XTypeGroup(
-        label: 'PNGs',
+        label: 'PNG',
         extensions: <String>['png', 'PNG'],
       ),
       XTypeGroup(

--- a/lib/utils/file_selector.dart
+++ b/lib/utils/file_selector.dart
@@ -51,6 +51,10 @@ enum FileSelectorType {
   images(
     [
       XTypeGroup(
+        label: 'Images',
+        extensions: <String>['jpg', 'JPG', 'jpeg', 'JPEG', 'png', 'PNG', 'webp', 'WebP', 'WEBP', 'gif', 'GIF', 'bmp', 'BMP', 'tiff', 'TIFF', 'tif', 'TIF', 'heic', 'HEIC', 'svg', 'SVG'],
+      ),
+      XTypeGroup(
         label: 'JPG',
         extensions: <String>['jpg', 'JPG', 'jpeg', 'JPEG'],
       ),
@@ -88,6 +92,10 @@ enum FileSelectorType {
   ),
   videos(
     [
+      XTypeGroup(
+        label: 'Videos',
+        extensions: <String>['mp4', 'MP4', 'avi', 'AVI', 'webm', 'WebM', 'WEBM', 'mov', 'MOV', 'mkv', 'MKV', 'wmv', 'WMV', 'flv', 'FLV', 'mpeg', 'MPEG', '3gp', '3GP', 'ogg', 'OGG'],
+      ),
       XTypeGroup(
         label: 'MP4',
         extensions: <String>['mp4', 'MP4'],

--- a/lib/utils/file_selector.dart
+++ b/lib/utils/file_selector.dart
@@ -59,8 +59,8 @@ enum FileSelectorType {
         extensions: <String>['png', 'PNG'],
       ),
       XTypeGroup(
-        label: 'WEBP',
-        extensions: <String>['WebP', 'WEBP'],
+        label: 'WebP',
+        extensions: <String>['webp', 'WebP', 'WEBP'],
       ),
       XTypeGroup(
         label: 'GIF',


### PR DESCRIPTION
(I think this) Fixes https://github.com/krille-chan/fluffychat/issues/1667

I cannot use the tools for building, testing and automatically formatting this, so feel free to directly edit this PR, if necessary.

- [x] The commit message uses the format of [Conventional Commits](https://www.conventionalcommits.org)
- [x] The commit message describes what has been changed, why it has been changed and how it has been changed