### PR TITLE
fix: open space after clicking on navbar space item from settings page

### DIFF
--- a/lib/config/routes.dart
+++ b/lib/config/routes.dart
@@ -107,6 +107,7 @@ abstract class AppRoutes {
             ? TwoColumnLayout(
                 mainView: ChatList(
                   activeChat: state.pathParameters['roomid'],
+                  activeSpaceId: state.uri.queryParameters['spaceId'],
                   displayNavigationRail:
                       state.path?.startsWith('/rooms/settings') != true,
                 ),
@@ -125,6 +126,7 @@ abstract class AppRoutes {
                 ? const EmptyPage()
                 : ChatList(
                     activeChat: state.pathParameters['roomid'],
+                    activeSpaceId: state.uri.queryParameters['spaceId'],
                   ),
           ),
           routes: [

--- a/lib/pages/chat_list/chat_list.dart
+++ b/lib/pages/chat_list/chat_list.dart
@@ -72,11 +72,13 @@ extension LocalizedActiveFilter on ActiveFilter {
 class ChatList extends StatefulWidget {
   static BuildContext? contextForVoip;
   final String? activeChat;
+  final String? activeSpaceId;
   final bool displayNavigationRail;
 
   const ChatList({
     super.key,
     required this.activeChat,
+    this.activeSpaceId,
     this.displayNavigationRail = false,
   });
 
@@ -419,6 +421,8 @@ class ChatListController extends State<ChatList>
     });
 
     _checkTorBrowser();
+
+    _activeSpaceId = widget.activeSpaceId;
 
     super.initState();
   }


### PR DESCRIPTION
Hello! Currently, if you click on a space in the left-hand navigation bar while in the settings page, it take you to the main chats page, instead of selecting the space. It looks like there was a plan to use a query parameter to set the active space ID in this case (set in the onGoToSpaceId callback in settings_view.dart). This PR makes that query parameter set the activeSpaceId in chat_list.dart.

*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

Please make sure that your Pull Request meet the following **acceptance criteria**:

- [ x ] Code formatting and import sorting has been done with `dart format lib/ test/` and `dart run import_sorter:main --no-comments`
- [ x ] The commit message uses the format of [Conventional Commits](https://www.conventionalcommits.org)
- [ x ] The commit message describes what has been changed, why it has been changed and how it has been changed
- [ ] Every new feature or change of the design/GUI is linked to an approved design proposal in an issue
- [ ] Every new feature in the app or the build system has a strategy how this will be tested and maintained from now on for every release, e.g. a volunteer who takes over maintainership


### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ x ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS