### PR TITLE
fix: maintain state of text input dialog to prevent input being erased on keyboard submit

### DIFF
--- a/lib/widgets/adaptive_dialogs/dialog_text_field.dart
+++ b/lib/widgets/adaptive_dialogs/dialog_text_field.dart
@@ -17,6 +17,8 @@ class DialogTextField extends StatelessWidget {
   final TextInputType? keyboardType;
   final int? maxLength;
   final bool autocorrect = true;
+  final FocusNode? focusNode;
+  final void Function(String)? onSubmitted;
 
   const DialogTextField({
     super.key,
@@ -32,6 +34,8 @@ class DialogTextField extends StatelessWidget {
     this.controller,
     this.counterText,
     this.errorText,
+    this.focusNode,
+    this.onSubmitted,
   });
 
   @override
@@ -61,6 +65,8 @@ class DialogTextField extends StatelessWidget {
             suffixText: suffixText,
             counterText: counterText,
           ),
+          focusNode: focusNode,
+          onSubmitted: onSubmitted,
         );
       case TargetPlatform.iOS:
       case TargetPlatform.macOS:
@@ -78,6 +84,8 @@ class DialogTextField extends StatelessWidget {
               prefix: prefixText != null ? Text(prefixText) : null,
               suffix: suffixText != null ? Text(suffixText) : null,
               placeholder: labelText ?? hintText,
+              focusNode: focusNode,
+              onSubmitted: onSubmitted,
             ),
             if (errorText != null)
               Text(

--- a/lib/widgets/adaptive_dialogs/show_text_input_dialog.dart
+++ b/lib/widgets/adaptive_dialogs/show_text_input_dialog.dart
@@ -31,80 +31,162 @@ Future<String?> showTextInputDialog({
   return showAdaptiveDialog<String>(
     context: context,
     useRootNavigator: useRootNavigator,
-    builder: (context) {
-      final controller = TextEditingController(text: initialText);
-      final error = ValueNotifier<String?>(null);
-      return ConstrainedBox(
-        constraints: const BoxConstraints(maxWidth: 512),
-        child: AlertDialog.adaptive(
-          title: ConstrainedBox(
-            constraints: const BoxConstraints(maxWidth: 256),
-            child: Text(title),
-          ),
-          content: ConstrainedBox(
-            constraints: const BoxConstraints(maxWidth: 256),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                if (message != null)
-                  SelectableLinkify(
-                    text: message,
-                    textScaleFactor: MediaQuery.textScalerOf(context).scale(1),
-                    linkStyle: TextStyle(
-                      color: Theme.of(context).colorScheme.primary,
-                      decorationColor: Theme.of(context).colorScheme.primary,
-                    ),
-                    options: const LinkifyOptions(humanize: false),
-                    onOpen: (url) => UrlLauncher(context, url.url).launchUrl(),
-                  ),
-                const SizedBox(height: 16),
-                ValueListenableBuilder<String?>(
-                  valueListenable: error,
-                  builder: (context, error, _) {
-                    return DialogTextField(
-                      hintText: hintText,
-                      errorText: error,
-                      labelText: labelText,
-                      controller: controller,
-                      initialText: initialText,
-                      prefixText: prefixText,
-                      suffixText: suffixText,
-                      minLines: minLines,
-                      maxLines: maxLines,
-                      maxLength: maxLength,
-                      keyboardType: keyboardType,
-                    );
-                  },
-                ),
-              ],
-            ),
-          ),
-          actions: [
-            AdaptiveDialogAction(
-              onPressed: () => Navigator.of(context).pop(null),
-              child: Text(cancelLabel ?? L10n.of(context).cancel),
-            ),
-            AdaptiveDialogAction(
-              onPressed: () {
-                final input = controller.text;
-                final errorText = validator?.call(input);
-                if (errorText != null) {
-                  error.value = errorText;
-                  return;
-                }
-                Navigator.of(context).pop<String>(input);
-              },
-              autofocus: true,
-              child: Text(
-                okLabel ?? L10n.of(context).ok,
-                style: isDestructive
-                    ? TextStyle(color: Theme.of(context).colorScheme.error)
-                    : null,
-              ),
-            ),
-          ],
-        ),
-      );
-    },
+    builder: (context) => TextInputDialog(
+      title: title,
+      message: message,
+      okLabel: okLabel,
+      cancelLabel: cancelLabel,
+      hintText: hintText,
+      labelText: labelText,
+      initialText: initialText,
+      prefixText: prefixText,
+      suffixText: suffixText,
+      obscureText: obscureText,
+      isDestructive: isDestructive,
+      minLines: minLines,
+      maxLines: maxLines,
+      validator: validator,
+      keyboardType: keyboardType,
+      maxLength: maxLength,
+      autocorrect: autocorrect,
+    ),
   );
+}
+
+class TextInputDialog extends StatefulWidget {
+  final String title;
+  final String? message;
+  final String? okLabel;
+  final String? cancelLabel;
+  final bool useRootNavigator;
+  final String? hintText;
+  final String? labelText;
+  final String? initialText;
+  final String? prefixText;
+  final String? suffixText;
+  final bool obscureText;
+  final bool isDestructive;
+  final int? minLines;
+  final int? maxLines;
+  final String? Function(String input)? validator;
+  final TextInputType? keyboardType;
+  final int? maxLength;
+  final bool autocorrect;
+
+  const TextInputDialog({
+    super.key,
+    required this.title,
+    this.message,
+    this.okLabel,
+    this.cancelLabel,
+    this.useRootNavigator = true,
+    this.hintText,
+    this.labelText,
+    this.initialText,
+    this.prefixText,
+    this.suffixText,
+    this.obscureText = false,
+    this.isDestructive = false,
+    this.minLines,
+    this.maxLines,
+    this.maxLength,
+    this.keyboardType,
+    this.validator,
+    this.autocorrect = true,
+  });
+
+  @override
+  State<TextInputDialog> createState() => TextInputDialogState();
+}
+
+class TextInputDialogState extends State<TextInputDialog> {
+  final TextEditingController controller = TextEditingController();
+  final FocusNode focusNode = FocusNode();
+  String? error;
+
+  @override
+  void initState() {
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    controller.dispose();
+    focusNode.dispose();
+    super.dispose();
+  }
+
+  void _onSubmitted() {
+    final input = controller.text;
+    final errorText = widget.validator?.call(input);
+    if (errorText != null) {
+      setState(() => error = errorText);
+      return;
+    }
+    Navigator.of(context).pop<String>(input);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ConstrainedBox(
+      constraints: const BoxConstraints(maxWidth: 512),
+      child: AlertDialog.adaptive(
+        title: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 256),
+          child: Text(widget.title),
+        ),
+        content: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 256),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              if (widget.message != null)
+                SelectableLinkify(
+                  text: widget.message!,
+                  textScaleFactor: MediaQuery.textScalerOf(context).scale(1),
+                  linkStyle: TextStyle(
+                    color: Theme.of(context).colorScheme.primary,
+                    decorationColor: Theme.of(context).colorScheme.primary,
+                  ),
+                  options: const LinkifyOptions(humanize: false),
+                  onOpen: (url) => UrlLauncher(context, url.url).launchUrl(),
+                ),
+              const SizedBox(height: 16),
+              DialogTextField(
+                hintText: widget.hintText,
+                errorText: error,
+                labelText: widget.labelText,
+                controller: controller,
+                initialText: widget.initialText,
+                prefixText: widget.prefixText,
+                suffixText: widget.suffixText,
+                minLines: widget.minLines,
+                maxLines: widget.maxLines,
+                maxLength: widget.maxLength,
+                keyboardType: widget.keyboardType,
+                focusNode: focusNode,
+                onSubmitted: (_) => _onSubmitted,
+              ),
+            ],
+          ),
+        ),
+        actions: [
+          AdaptiveDialogAction(
+            onPressed: () => Navigator.of(context).pop(null),
+            child: Text(widget.cancelLabel ?? L10n.of(context).cancel),
+          ),
+          AdaptiveDialogAction(
+            onPressed: _onSubmitted,
+            autofocus: true,
+            child: Text(
+              widget.okLabel ?? L10n.of(context).ok,
+              style: widget.isDestructive
+                  ? TextStyle(color: Theme.of(context).colorScheme.error)
+                  : null,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
 }


### PR DESCRIPTION
Hello! I ran into a problem with some text input dialogs on mobile. Sometimes, the mobile keyboard text input action defaults to a submit button (I think this happens when maxLines is set to 1, but it could be triggered in other ways). When this happens, clicking the submit button on the mobile keyboard does not submit the dialog, and instead erases the current text in the dialog.

This is because the TextEditingController in the text input dialog is remade each time that the dialog rebuilds.

I tested with wrapping the dialog in a StatefulBuilder, but had no luck with maintaining the text input, so instead I turned the dialog into a StatefulWidget. This also enables the TextEditingController to be disposed, preventing it from building up in memory.

I also added an onSubmitted callback to the text input dialog that calls the same function also the submit button. It seems intuitive that these two actions should do the same thing.

*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

Please make sure that your Pull Request meet the following **acceptance criteria**:

- [ x ] Code formatting and import sorting has been done with `dart format lib/ test/` and `dart run import_sorter:main --no-comments`
- [ x ] The commit message uses the format of [Conventional Commits](https://www.conventionalcommits.org)
- [ x ] The commit message describes what has been changed, why it has been changed and how it has been changed
- [ ] Every new feature or change of the design/GUI is linked to an approved design proposal in an issue
- [ ] Every new feature in the app or the build system has a strategy how this will be tested and maintained from now on for every release, e.g. a volunteer who takes over maintainership


### Pull Request has been tested on:

- [ x ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS