### PR TITLE
feat: make empty tab text more inclusive

### DIFF
--- a/assets/l10n/intl_en.arb
+++ b/assets/l10n/intl_en.arb
@@ -3236,5 +3236,6 @@
   "enterNewChat": "Enter new chat",
   "approve": "Approve",
   "youHaveKnocked": "You have knocked",
-  "pleaseWaitUntilInvited": "Please wait now, until someone from the room invites you."
+  "pleaseWaitUntilInvited": "Please wait now, until someone from the room invites you.",
+  "nothingHereYet": "Nothing here yet"
 }

--- a/lib/pages/chat_list/chat_list_body.dart
+++ b/lib/pages/chat_list/chat_list_body.dart
@@ -224,7 +224,7 @@ class ChatListViewBody extends StatelessWidget {
                             child: Text(
                               client.rooms.isEmpty
                                   ? L10n.of(context).noChatsFoundHere
-                                  : L10n.of(context).noMoreChatsFound,
+                                  : L10n.of(context).nothingHereYet,
                               textAlign: TextAlign.center,
                               style: TextStyle(
                                 fontSize: 18,


### PR DESCRIPTION
- Changes empty tab text to say "Nothing here yet" instead of "No more chats found..."

Empty tabs say 'No more chats found...'. This can confuse the distinction between direct chats and groups, and is inaccurate for space filtering tabs. 

*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

Please make sure that your Pull Request meet the following **acceptance criteria**:

- [ x ] Code formatting and import sorting has been done with `dart format lib/ test/` and `dart run import_sorter:main --no-comments`
- [ x ] The commit message uses the format of [Conventional Commits](https://www.conventionalcommits.org)
- [ x ] The commit message describes what has been changed, why it has been changed and how it has been changed
- [ ] Every new feature or change of the design/GUI is linked to an approved design proposal in an issue
- [ ] Every new feature in the app or the build system has a strategy how this will be tested and maintained from now on for every release, e.g. a volunteer who takes over maintainership


### Pull Request has been tested on:

- [ x ] Android
- [ x ] iOS
- [ x ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS