### PR TITLE
chore: replace navigation to space parents with back button and popup menu for spaces with multiple parents

### DIFF
--- a/lib/pages/chat_list/space_view.dart
+++ b/lib/pages/chat_list/space_view.dart
@@ -228,14 +228,49 @@ class _SpaceViewState extends State<SpaceView> {
     final room = Matrix.of(context).client.getRoomById(widget.spaceId);
     final displayname =
         room?.getLocalizedDisplayname() ?? L10n.of(context).nothingFound;
+
+    final joinedParents = room?.spaceParents
+        .map((parent) {
+          final roomId = parent.roomId;
+          if (roomId == null) return null;
+          return room.client.getRoomById(roomId);
+        })
+        .whereType<Room>()
+        .toList();
+
     return Scaffold(
       appBar: AppBar(
-        leading: FluffyThemes.isColumnMode(context)
-            ? null
+        leading: joinedParents?.isEmpty ?? true
+            ? FluffyThemes.isColumnMode(context)
+                ? null
+                : Center(
+                    child: CloseButton(
+                      onPressed: widget.onBack,
+                    ),
+                  )
             : Center(
-                child: CloseButton(
-                  onPressed: widget.onBack,
-                ),
+                child: joinedParents!.length == 1
+                    ? IconButton(
+                        icon: const Icon(Icons.arrow_back_outlined),
+                        onPressed: () =>
+                            widget.toParentSpace(joinedParents.first.id),
+                      )
+                    : PopupMenuButton(
+                        icon: const Icon(Icons.arrow_back_outlined),
+                        itemBuilder: (context) {
+                          return [
+                            ...joinedParents.mapIndexed((i, room) {
+                              return PopupMenuItem(
+                                value: i,
+                                child: Text(room.getLocalizedDisplayname()),
+                              );
+                            }),
+                          ];
+                        },
+                        onSelected: (i) {
+                          widget.toParentSpace(joinedParents[i].id);
+                        },
+                      ),
               ),
         automaticallyImplyLeading: false,
         titleSpacing: FluffyThemes.isColumnMode(context) ? null : 0,
@@ -335,14 +370,6 @@ class _SpaceViewState extends State<SpaceView> {
                     .where((room) => childrenIds.remove(room.id))
                     .toList();
 
-                final joinedParents = room.spaceParents
-                    .map((parent) {
-                      final roomId = parent.roomId;
-                      if (roomId == null) return null;
-                      return room.client.getRoomById(roomId);
-                    })
-                    .whereType<Room>()
-                    .toList();
                 final filter = _filterController.text.trim().toLowerCase();
                 return CustomScrollView(
                   slivers: [
@@ -379,47 +406,6 @@ class _SpaceViewState extends State<SpaceView> {
                           ),
                         ),
                       ),
-                    ),
-                    SliverList.builder(
-                      itemCount: joinedParents.length,
-                      itemBuilder: (context, i) {
-                        final displayname =
-                            joinedParents[i].getLocalizedDisplayname();
-                        return Padding(
-                          padding: const EdgeInsets.symmetric(
-                            horizontal: 8,
-                            vertical: 1,
-                          ),
-                          child: Material(
-                            borderRadius:
-                                BorderRadius.circular(AppConfig.borderRadius),
-                            clipBehavior: Clip.hardEdge,
-                            child: ListTile(
-                              minVerticalPadding: 0,
-                              leading: Icon(
-                                Icons.adaptive.arrow_back_outlined,
-                                size: 16,
-                              ),
-                              title: Row(
-                                children: [
-                                  Avatar(
-                                    mxContent: joinedParents[i].avatar,
-                                    name: displayname,
-                                    size: Avatar.defaultSize / 2,
-                                    borderRadius: BorderRadius.circular(
-                                      AppConfig.borderRadius / 4,
-                                    ),
-                                  ),
-                                  const SizedBox(width: 8),
-                                  Expanded(child: Text(displayname)),
-                                ],
-                              ),
-                              onTap: () =>
-                                  widget.toParentSpace(joinedParents[i].id),
-                            ),
-                          ),
-                        );
-                      },
                     ),
                     SliverList.builder(
                       itemCount: joinedRooms.length,


### PR DESCRIPTION
Hello! This is a change to navigation from a subspace back to parent spaces discussed in #1772 . It replaces the list of tiles with a back button that goes back to the parents space if there is only one, or shows a popup with parent space options if there are multiple.

*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

Please make sure that your Pull Request meet the following **acceptance criteria**:

- [x] Code formatting and import sorting has been done with `dart format lib/ test/` and `dart run import_sorter:main --no-comments`
- [x] The commit message uses the format of [Conventional Commits](https://www.conventionalcommits.org)
- [x] The commit message describes what has been changed, why it has been changed and how it has been changed
- [ ] Every new feature or change of the design/GUI is linked to an approved design proposal in an issue
- [ ] Every new feature in the app or the build system has a strategy how this will be tested and maintained from now on for every release, e.g. a volunteer who takes over maintainership


### Pull Request has been tested on:

- [x] Android
- [ ] iOS
- [x] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS