### PR TITLE
fix: fix compile error related to MxcImage

### DIFF
--- a/lib/widgets/mxc_image.dart
+++ b/lib/widgets/mxc_image.dart
@@ -107,7 +107,7 @@ class _MxcImageState extends State<MxcImage> {
     }
   }
 
-  void _tryLoad(_) async {
+  void _tryLoad() async {
     if (_imageData != null) {
       return;
     }
@@ -116,14 +116,14 @@ class _MxcImageState extends State<MxcImage> {
     } on IOException catch (_) {
       if (!mounted) return;
       await Future.delayed(widget.retryDuration);
-      _tryLoad(_);
+      _tryLoad();
     }
   }
 
   @override
   void initState() {
     super.initState();
-    WidgetsBinding.instance.addPostFrameCallback(_tryLoad);
+    WidgetsBinding.instance.addPostFrameCallback((_) => _tryLoad());
   }
 
   Widget placeholder(BuildContext context) =>


### PR DESCRIPTION
### Description
 - We ran into this error after updating Flutter from 3.27 to 3.32:
  ```
lib/widgets/mxc_image.dart:119:16: Error: The getter '_' isn't defined for the class '_MxcImageState'.
     - '_MxcImageState' is from 'package:fluffychat/widgets/mxc_image.dart' ('lib/widgets/mxc_image.dart').
    Try correcting the name to the name of an existing getter, or defining a getter or field named '_'.
          _tryLoad(_);
  ```

  (see https://github.com/NixOS/nixpkgs/pull/416687/files#diff-e5453ee4fc425323a73d404a0133a78ee8e79cad7c72c31663c87edb48fe11d4R35).

 - This patch fixes that error.
- **We are not sure how this code builds without errors on your side.**
This trivial snippet fails to compile on DartPad: [Minimal reproducer](https://dartpad.dev/?id=7c373a0315906ded0e65d5ae977b6a39)


### Template
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

Please make sure that your Pull Request meet the following **acceptance criteria**:

- [x] Code formatting and import sorting has been done with `dart format lib/ test/` and `dart run import_sorter:main --no-comments`
- [x] The commit message uses the format of [Conventional Commits](https://www.conventionalcommits.org)
- [x] The commit message describes what has been changed, why it has been changed and how it has been changed
- [x] Every new feature or change of the design/GUI is linked to an approved design proposal in an issue
- [x] Every new feature in the app or the build system has a strategy how this will be tested and maintained from now on for every release, e.g. a volunteer who takes over maintainership


### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [x] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS