### PR TITLE
fix: only show text messages in chat message search

### DIFF
--- a/lib/pages/chat_search/chat_search_message_tab.dart
+++ b/lib/pages/chat_search/chat_search_message_tab.dart
@@ -51,6 +51,12 @@ class ChatSearchMessageTab extends StatelessWidget {
           );
         }
         final events = snapshot.data?.$1 ?? [];
+        events.removeWhere(
+          (event) =>
+              event.type != EventTypes.Message ||
+              event.messageType != MessageTypes.Text ||
+              event.redacted,
+        );
 
         return SelectionArea(
           child: ListView.separated(


### PR DESCRIPTION
In chat message search, filters out events for which keyword searching is not useful:

- non-message events
- non-text messages
- redacted messages

*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

Please make sure that your Pull Request meet the following **acceptance criteria**:

- [x] Code formatting and import sorting has been done with `dart format lib/ test/` and `dart run import_sorter:main --no-comments`
- [x] The commit message uses the format of [Conventional Commits](https://www.conventionalcommits.org)
- [x] The commit message describes what has been changed, why it has been changed and how it has been changed
- [ ] Every new feature or change of the design/GUI is linked to an approved design proposal in an issue
- [ ] Every new feature in the app or the build system has a strategy how this will be tested and maintained from now on for every release, e.g. a volunteer who takes over maintainership


### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [x] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

Closes #1999 