### PR TITLE
fix: limit characters and lines so redact message can't be too long

### DIFF
--- a/lib/pages/chat/chat.dart
+++ b/lib/pages/chat/chat.dart
@@ -843,6 +843,9 @@ class ChatController extends State<ChatPageWithRoom>
             message: L10n.of(context).redactMessageDescription,
             isDestructive: true,
             hintText: L10n.of(context).optionalRedactReason,
+            maxLength: 255,
+            maxLines: 3,
+            minLines: 1,
             okLabel: L10n.of(context).remove,
             cancelLabel: L10n.of(context).cancel,
           )


### PR DESCRIPTION
Before, if the user typed too many lines it would overflow past the input box and also leave a very long message in chat. Now, it is limited and won't expand in the input box past 4 lines. This fixes #2066 

*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

Please make sure that your Pull Request meet the following **acceptance criteria**:

- [ ] Code formatting and import sorting has been done with `dart format lib/ test/` and `dart run import_sorter:main --no-comments`
- [x] The commit message uses the format of [Conventional Commits](https://www.conventionalcommits.org)
- [x] The commit message describes what has been changed, why it has been changed and how it has been changed
- [x] Every new feature or change of the design/GUI is linked to an approved design proposal in an issue
- [ ] Every new feature in the app or the build system has a strategy how this will be tested and maintained from now on for every release, e.g. a volunteer who takes over maintainership


### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [x] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS