### PR TITLE
fix: remove highlight when message is unpinned

### DIFF
--- a/lib/pages/chat/chat.dart
+++ b/lib/pages/chat/chat.dart
@@ -1203,6 +1203,7 @@ class ChatController extends State<ChatPageWithRoom>
         pinnedEventIds.contains(selectedEventIds.single);
     if (unpin) {
       unpinEvent(selectedEventIds.single);
+      return;
     } else {
       pinnedEventIds.addAll(selectedEventIds);
     }

--- a/lib/pages/chat/chat.dart
+++ b/lib/pages/chat/chat.dart
@@ -1184,6 +1184,11 @@ class ChatController extends State<ChatPageWithRoom>
     if (response == OkCancelResult.ok) {
       final events = room.pinnedEventIds
         ..removeWhere((oldEvent) => oldEvent == eventId);
+      if (scrollToEventIdMarker == eventId) {
+        setState(() {
+          scrollToEventIdMarker = null;
+        });
+      }
       showFutureLoadingDialog(
         context: context,
         future: () => room.setPinnedEvents(events),
@@ -1197,7 +1202,7 @@ class ChatController extends State<ChatPageWithRoom>
     final unpin = selectedEventIds.length == 1 &&
         pinnedEventIds.contains(selectedEventIds.single);
     if (unpin) {
-      pinnedEventIds.removeWhere(selectedEventIds.contains);
+      unpinEvent(selectedEventIds.single);
     } else {
       pinnedEventIds.addAll(selectedEventIds);
     }

--- a/lib/pages/chat/events/message.dart
+++ b/lib/pages/chat/events/message.dart
@@ -293,7 +293,10 @@ class Message extends StatelessWidget {
                                     borderRadius: BorderRadius.circular(
                                       AppConfig.borderRadius / 2,
                                     ),
-                                    color: selected || highlightMarker
+                                    color: selected ||
+                                            (highlightMarker &&
+                                                event.room.pinnedEventIds
+                                                    .contains(event.eventId))
                                         ? theme.colorScheme.secondaryContainer
                                             .withAlpha(128)
                                         : Colors.transparent,

--- a/lib/pages/chat/events/message.dart
+++ b/lib/pages/chat/events/message.dart
@@ -293,10 +293,7 @@ class Message extends StatelessWidget {
                                     borderRadius: BorderRadius.circular(
                                       AppConfig.borderRadius / 2,
                                     ),
-                                    color: selected ||
-                                            (highlightMarker &&
-                                                event.room.pinnedEventIds
-                                                    .contains(event.eventId))
+                                    color: selected || highlightMarker
                                         ? theme.colorScheme.secondaryContainer
                                             .withAlpha(128)
                                         : Colors.transparent,


### PR DESCRIPTION
Removes highlight that you get from scrolling to a pinned message, when that message is unpinned. It also calls the unpinEvent function from clicking on the upper right pin icon, as well as the one on the pin bar so that the actions are consistent. Closes #2078 

*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

Please make sure that your Pull Request meet the following **acceptance criteria**:

- [ ] Code formatting and import sorting has been done with `dart format lib/ test/` and `dart run import_sorter:main --no-comments`
- [x] The commit message uses the format of [Conventional Commits](https://www.conventionalcommits.org)
- [x] The commit message describes what has been changed, why it has been changed and how it has been changed
- [x] Every new feature or change of the design/GUI is linked to an approved design proposal in an issue
- [ ] Every new feature in the app or the build system has a strategy how this will be tested and maintained from now on for every release, e.g. a volunteer who takes over maintainership


### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [x] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS