### PR TITLE
fix: reduce `ChatListItem` build time

### DIFF
--- a/lib/pages/chat_list/chat_list_item.dart
+++ b/lib/pages/chat_list/chat_list_item.dart
@@ -277,45 +277,63 @@ class ChatListItem extends StatelessWidget {
                                             directChatMatrixId !=
                                                 room.lastEvent?.senderId),
                                       )
-                                    : null,
-                                initialData:
-                                    lastEvent?.calcLocalizedBodyFallback(
-                                  MatrixLocals(L10n.of(context)),
-                                  hideReply: true,
-                                  hideEdit: true,
-                                  plaintextBody: true,
-                                  removeMarkdown: true,
-                                  withSenderNamePrefix: (!isDirectChat ||
-                                      directChatMatrixId !=
-                                          room.lastEvent?.senderId),
-                                ),
-                                builder: (context, snapshot) => Text(
-                                  room.membership == Membership.invite
-                                      ? room
-                                              .getState(
-                                                EventTypes.RoomMember,
-                                                room.client.userID!,
-                                              )
-                                              ?.content
-                                              .tryGet<String>('reason') ??
-                                          (isDirectChat
-                                              ? L10n.of(context).newChatRequest
-                                              : L10n.of(context)
-                                                  .inviteGroupChat)
-                                      : snapshot.data ??
-                                          L10n.of(context).emptyChat,
-                                  softWrap: false,
-                                  maxLines: room.notificationCount >= 1 ? 2 : 1,
-                                  overflow: TextOverflow.ellipsis,
-                                  style: TextStyle(
-                                    color: unread || room.hasNewMessages
-                                        ? theme.colorScheme.onSurface
-                                        : theme.colorScheme.outline,
-                                    decoration: room.lastEvent?.redacted == true
-                                        ? TextDecoration.lineThrough
-                                        : null,
-                                  ),
-                                ),
+                                    : Future(
+                                        () => lastEvent
+                                            ?.calcLocalizedBodyFallback(
+                                          MatrixLocals(L10n.of(context)),
+                                          hideReply: true,
+                                          hideEdit: true,
+                                          plaintextBody: true,
+                                          removeMarkdown: true,
+                                          withSenderNamePrefix:
+                                              (!isDirectChat ||
+                                                  directChatMatrixId !=
+                                                      room.lastEvent?.senderId),
+                                        ),
+                                      ),
+                                builder: (context, snapshot) => snapshot.hasData
+                                    ? Text(
+                                        room.membership == Membership.invite
+                                            ? room
+                                                    .getState(
+                                                      EventTypes.RoomMember,
+                                                      room.client.userID!,
+                                                    )
+                                                    ?.content
+                                                    .tryGet<String>('reason') ??
+                                                (isDirectChat
+                                                    ? L10n.of(context)
+                                                        .newChatRequest
+                                                    : L10n.of(context)
+                                                        .inviteGroupChat)
+                                            : snapshot.data ??
+                                                L10n.of(context).emptyChat,
+                                        softWrap: false,
+                                        maxLines:
+                                            room.notificationCount >= 1 ? 2 : 1,
+                                        overflow: TextOverflow.ellipsis,
+                                        style: TextStyle(
+                                          color: unread || room.hasNewMessages
+                                              ? theme.colorScheme.onSurface
+                                              : theme.colorScheme.outline,
+                                          decoration:
+                                              room.lastEvent?.redacted == true
+                                                  ? TextDecoration.lineThrough
+                                                  : null,
+                                        ),
+                                      )
+                                    : Container(
+                                        decoration: BoxDecoration(
+                                          color: theme
+                                              .textTheme.bodyLarge!.color!
+                                              .withAlpha(50),
+                                          borderRadius:
+                                              BorderRadius.circular(3),
+                                        ),
+                                        height: 12,
+                                        margin:
+                                            const EdgeInsets.only(right: 22),
+                                      ),
                               ),
                   ),
                   const SizedBox(width: 8),


### PR DESCRIPTION
Related to https://github.com/krille-chan/fluffychat/issues/293. Note that this commit introduces a minor UI change.

My survey shows that, although not the only factor, `ChatListItem` does contribute a lot to the frame time of the chat list. What makes the build process so slow is that `Event.calcLocalizedBodyFallback()` is called in `ChatListItem.build()`. `Event.calcLocalizedBodyFallback()` does some regex, markdown and HTML work, which takes much time.

Time-consuming work should never been done in build methods, so I put it in a `Future`. Since it served as a placeholder for subtitle, it's necessary to find another placeholder. I think the subtitle of `DummyChatListItem` fits well. It's shown as the subtitle of a chat list before the actual content is parsed.

### Pull Request has been tested on:

- [x] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS