### PR TITLE
fix: build `HtmlMessage` lazily

### DIFF
--- a/lib/pages/chat/events/html_message.dart
+++ b/lib/pages/chat/events/html_message.dart
@@ -506,17 +506,25 @@ class HtmlMessage extends StatelessWidget {
     }
   }
 
+  // `dom.Element.html('')` won't work
+  static final _emptyHtmlBody = dom.Element.html('<body></body>');
+
   @override
   Widget build(BuildContext context) {
-    final element = parser.parse(html).body ?? dom.Element.html('');
-    return Text.rich(
-      _renderHtml(element, context),
-      style: TextStyle(
-        fontSize: fontSize,
-        color: textColor,
+    return FutureBuilder(
+      future: Future(
+        () => _renderHtml(parser.parse(html).body ?? _emptyHtmlBody, context),
       ),
-      maxLines: limitHeight ? 64 : null,
-      overflow: TextOverflow.fade,
+      initialData: _renderHtml(_emptyHtmlBody, context),
+      builder: (context, snapshot) => Text.rich(
+        snapshot.data!,
+        style: TextStyle(
+          fontSize: fontSize,
+          color: textColor,
+        ),
+        maxLines: limitHeight ? 64 : null,
+        overflow: TextOverflow.fade,
+      ),
     );
   }
 }


### PR DESCRIPTION
Related to https://github.com/krille-chan/fluffychat/issues/293, reducing jank on the chat page. This patch avoids parsing HTML in the `build()` method. Note that there is a UX change. Bubbles now resize themselves more frequently.

### Problems to be resolved:

 - [ ] When scrolling down, newly appeared bubbles resize themselves and thus push the older ones up. This is annoying.

### Pull Request has been tested on:

- [x] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS