### PR TITLE
fix: Use noTransitionPageBuilder on the settings ShellRoute too

### DIFF
--- a/lib/config/routes.dart
+++ b/lib/config/routes.dart
@@ -186,7 +186,7 @@ abstract class AppRoutes {
               redirect: loggedOutRedirect,
             ),
             ShellRoute(
-              pageBuilder: (context, state, child) => defaultPageBuilder(
+              pageBuilder: (context, state, child) => noTransitionPageBuilder(
                 context,
                 state,
                 FluffyThemes.isColumnMode(context)


### PR DESCRIPTION
This is related to PR #1653. That PR fixed the app crash when rotating the device on the main screen, but the fix wasn't applied to the settings screen, and I still experienced crashes there. This PR applies the same fix to the Settings ShellRoute.

This should also close the following issues:
#1643
#1436 
#1030
#1285
#974

The only downside is that there is no more transition animation between main screen and settings screen in the portrait mode. I couldn't figure out how to fix it while preserving the animation. The solution I could think of would require moving the  `isColumnMode` related logic inside the TwoColumnLayout widget.

- [x] Code formatting and import sorting has been done with `dart format lib/ test/` and `dart run import_sorter:main --no-comments`
- [x] The commit message uses the format of [Conventional Commits](https://www.conventionalcommits.org)
- [x] The commit message describes what has been changed, why it has been changed and how it has been changed
- [ ] Every new feature or change of the design/GUI is linked to an approved design proposal in an issue
- [ ] Every new feature in the app or the build system has a strategy how this will be tested and maintained from now on for every release, e.g. a volunteer who takes over maintainership


### Pull Request has been tested on:

- [x] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS