### PR TITLE
feat: serverside low priority chat and room categorization

### DIFF
--- a/lib/pages/chat_list/chat_list_body.dart
+++ b/lib/pages/chat_list/chat_list_body.dart
@@ -14,6 +14,7 @@ import 'package:fluffychat/pages/chat_list/status_msg_list.dart';
 import 'package:fluffychat/utils/stream_extension.dart';
 import 'package:fluffychat/widgets/adaptive_dialogs/public_room_dialog.dart';
 import 'package:fluffychat/widgets/avatar.dart';
+import 'package:fluffychat/widgets/room_category_tile.dart';
 import '../../config/themes.dart';
 import '../../widgets/adaptive_dialogs/user_dialog.dart';
 import '../../widgets/matrix.dart';
@@ -250,22 +251,25 @@ class ChatListViewBody extends StatelessWidget {
                   ),
                 ),
               if (client.prevBatch != null)
-                SliverList.builder(
-                  itemCount: rooms.length,
-                  itemBuilder: (BuildContext context, int i) {
-                    final room = rooms[i];
-                    final space = spaceDelegateCandidates[room.id];
-                    return ChatListItem(
-                      room,
-                      space: space,
-                      key: Key('chat_list_item_${room.id}'),
-                      filter: filter,
-                      onTap: () => controller.onChatTap(room),
-                      onLongPress: (context) =>
-                          controller.chatContextAction(room, context, space),
-                      activeChat: controller.activeChat == room.id,
-                    );
-                  },
+                SliverList(
+                  delegate: SliverChildBuilderDelegate(
+                    (context, index) {
+                      final categories = controller.categorizedRooms;
+                      if (index >= categories.length) return null;
+                      final category = categories[index];
+                      return RoomCategoryTile(
+                        category: category,
+                        onToggle: () =>
+                            controller.toggleCategoryCollapse(category.id),
+                        onRoomTap: controller.onChatTap,
+                        onRoomLongPress: (room, context) =>
+                            controller.chatContextAction(room, context),
+                        activeChat: controller.activeChat,
+                        filter: filter,
+                      );
+                    },
+                    childCount: controller.categorizedRooms.length,
+                  ),
                 ),
             ],
           ),

--- a/lib/widgets/room_category_tile.dart
+++ b/lib/widgets/room_category_tile.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+
+import 'package:matrix/matrix.dart';
+
+import 'package:fluffychat/config/themes.dart';
+import 'package:fluffychat/pages/chat_list/chat_list.dart';
+import 'package:fluffychat/pages/chat_list/chat_list_item.dart';
+
+class RoomCategoryTile extends StatelessWidget {
+  final RoomCategory category;
+  final VoidCallback onToggle;
+  final Function(Room) onRoomTap;
+  final Function(Room, BuildContext) onRoomLongPress;
+  final String? activeChat;
+  final String filter;
+
+  const RoomCategoryTile({
+    super.key,
+    required this.category,
+    required this.onToggle,
+    required this.onRoomTap,
+    required this.onRoomLongPress,
+    this.activeChat,
+    this.filter = '',
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Material(
+          color: theme.colorScheme.surface,
+          child: ListTile(
+            dense: true,
+            contentPadding: const EdgeInsets.symmetric(horizontal: 16.0),
+            leading: Icon(
+              category.isCollapsed ? Icons.chevron_right : Icons.expand_more,
+              size: 20,
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+            title: Text(
+              '${category.name} (${category.rooms.length})',
+              style: theme.textTheme.titleSmall?.copyWith(
+                fontWeight: FontWeight.w600,
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+            onTap: onToggle,
+          ),
+        ),
+        AnimatedContainer(
+          duration: FluffyThemes.animationDuration,
+          curve: FluffyThemes.animationCurve,
+          height: category.isCollapsed ? 0 : null,
+          child: ClipRect(
+            child: AnimatedOpacity(
+              duration: FluffyThemes.animationDuration,
+              curve: FluffyThemes.animationCurve,
+              opacity: category.isCollapsed ? 0.0 : 1.0,
+              child: category.isCollapsed
+                  ? const SizedBox.shrink()
+                  : Column(
+                      children: category.rooms
+                          .map(
+                            (room) => ChatListItem(
+                              room,
+                              key: Key('chat_list_item_${room.id}'),
+                              filter: filter,
+                              onTap: () => onRoomTap(room),
+                              onLongPress: (context) =>
+                                  onRoomLongPress(room, context),
+                              activeChat: activeChat == room.id,
+                            ),
+                          )
+                          .toList(),
+                    ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

Please make sure that your Pull Request meet the following **acceptance criteria**:

- [X] Code formatting and import sorting has been done with `dart format lib/ test/` and `dart run import_sorter:main --no-comments`
- [X] The commit message uses the format of [Conventional Commits](https://www.conventionalcommits.org)
- [X] The commit message describes what has been changed, why it has been changed and how it has been changed
- [X] Every new feature or change of the design/GUI is linked to an approved design proposal in an issue
- [ ] Every new feature in the app or the build system has a strategy how this will be tested and maintained from now on for every release, e.g. a volunteer who takes over maintainership


### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [X] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

This fulfills the https://github.com/krille-chan/fluffychat/issues/692 issue in which rooms can be deprioritized into a lowermost collapsed tile to hide bothersome or inane spaces while prioritizing pinned and normal DM content.

This has so far only been tested on a Linux system in the native GUI to function and uses the server data tagging system to sync room organization between fluffy clients and must be tried on more platforms.

Looking for guidance on the last checklist item of testing and maintainership here if simple review is not acceptable.