### PR TITLE
chore: use time format based on system settings

### DIFF
--- a/lib/utils/date_time_extension.dart
+++ b/lib/utils/date_time_extension.dart
@@ -83,6 +83,7 @@ extension DateTimeExtension on DateTime {
 
     final l10n24h = L10n.of(context).alwaysUse24HourFormat == 'true';
 
+    // https://github.com/krille-chan/fluffychat/pull/1457#discussion_r1836817914
     if (PlatformInfos.isAndroid) {
       return mediaQuery24h;
     } else if (PlatformInfos.isIOS) {


### PR DESCRIPTION
Based on PR #1457, but handle the different expected behavior of `MediaQuery.alwaysUse24HourFormatOf`.

Please make sure that your Pull Request meet the following **acceptance criteria**:

- [x] Code formatting and import sorting has been done with `dart format lib/ test/` and `dart run import_sorter:main --no-comments`
- [x] The commit message uses the format of [Conventional Commits](https://www.conventionalcommits.org)
- [x] The commit message describes what has been changed, why it has been changed and how it has been changed
- [ ] Every new feature or change of the design/GUI is linked to an approved design proposal in an issue
- [ ] Every new feature in the app or the build system has a strategy how this will be tested and maintained from now on for every release, e.g. a volunteer who takes over maintainership


### Pull Request has been tested on:

- [x] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS