### PR TITLE
feat: added support for TextCapitalization in DialogTextField

### DIFF
--- a/lib/pages/chat/send_file_dialog.dart
+++ b/lib/pages/chat/send_file_dialog.dart
@@ -332,6 +332,7 @@ class SendFileDialogState extends State<SendFileDialog> {
                       padding: const EdgeInsets.only(bottom: 8.0),
                       child: DialogTextField(
                         controller: _labelTextController,
+                        textCapitalization: TextCapitalization.sentences,
                         labelText: L10n.of(context).optionalMessage,
                         minLines: 1,
                         maxLines: 3,

--- a/lib/widgets/adaptive_dialogs/dialog_text_field.dart
+++ b/lib/widgets/adaptive_dialogs/dialog_text_field.dart
@@ -17,22 +17,23 @@ class DialogTextField extends StatelessWidget {
   final TextInputType? keyboardType;
   final int? maxLength;
   final bool autocorrect = true;
+  final TextCapitalization textCapitalization;
 
-  const DialogTextField({
-    super.key,
-    this.hintText,
-    this.labelText,
-    this.initialText,
-    this.prefixText,
-    this.suffixText,
-    this.minLines,
-    this.maxLines,
-    this.keyboardType,
-    this.maxLength,
-    this.controller,
-    this.counterText,
-    this.errorText,
-  });
+  const DialogTextField(
+      {super.key,
+      this.hintText,
+      this.labelText,
+      this.initialText,
+      this.prefixText,
+      this.suffixText,
+      this.minLines,
+      this.maxLines,
+      this.keyboardType,
+      this.maxLength,
+      this.controller,
+      this.counterText,
+      this.errorText,
+      this.textCapitalization = TextCapitalization.none});
 
   @override
   Widget build(BuildContext context) {
@@ -53,6 +54,7 @@ class DialogTextField extends StatelessWidget {
           maxLength: maxLength,
           keyboardType: keyboardType,
           autocorrect: autocorrect,
+          textCapitalization: textCapitalization,
           decoration: InputDecoration(
             errorText: errorText,
             hintText: hintText,
@@ -75,6 +77,7 @@ class DialogTextField extends StatelessWidget {
               maxLength: maxLength,
               keyboardType: keyboardType,
               autocorrect: autocorrect,
+              textCapitalization: textCapitalization,
               prefix: prefixText != null ? Text(prefixText) : null,
               suffix: suffixText != null ? Text(suffixText) : null,
               placeholder: labelText ?? hintText,


### PR DESCRIPTION
This is my first contribution, and I'm still new to Dart. Apologies if the implementation isn't ideal.

I often add images with captions, and having to manually capitalize the first letter every time is tedious. This patch adds automatic capitalization to the text field.

- [x] Code formatting and import sorting has been done with `dart format lib/ test/` and `dart run import_sorter:main --no-comments`
- [x] The commit message uses the format of [Conventional Commits](https://www.conventionalcommits.org)
- [x] The commit message describes what has been changed, why it has been changed and how it has been changed
- [x] Every new feature or change of the design/GUI is linked to an approved design proposal in an issue
- [x] Every new feature in the app or the build system has a strategy how this will be tested and maintained from now on for every release, e.g. a volunteer who takes over maintainership


### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [x] Browser (Chromium based)
- [x] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS