### PR TITLE
Add direct chat functionality using URL parameters

### DIFF
--- a/lib/pages/chat_list/chat_list.dart
+++ b/lib/pages/chat_list/chat_list.dart
@@ -11,6 +11,7 @@ import 'package:go_router/go_router.dart';
 import 'package:matrix/matrix.dart' as sdk;
 import 'package:matrix/matrix.dart';
 import 'package:receive_sharing_intent/receive_sharing_intent.dart';
+import 'package:universal_html/html.dart' as html;
 
 import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/l10n/l10n.dart';
@@ -802,6 +803,16 @@ class ChatListController extends State<ChatList>
           ),
         ),
       );
+    }
+
+    final uri = Uri.parse(html.window.location.href);
+    final userID = uri.queryParameters['direct'];
+    if (userID != null) {
+      final roomID = await client.startDirectChat(
+        userID,
+        enableEncryption: false,
+      );
+      router.go('/rooms/$roomID');
     }
   }
 


### PR DESCRIPTION
Maybe you already familiar with a wa.me/+7 (whatsapp) or t.me/+7 (telegram) links.
So this merge request starts direct chat with a recipient using http URL parameter `?direct=<matrix-user-id>`.

- [ ] Code formatting and import sorting has been done with `dart format lib/ test/` and `dart run import_sorter:main --no-comments`
- [ ] The commit message uses the format of [Conventional Commits](https://www.conventionalcommits.org)
- [ ] The commit message describes what has been changed, why it has been changed and how it has been changed
- [ ] Every new feature or change of the design/GUI is linked to an approved design proposal in an issue
- [ ] Every new feature in the app or the build system has a strategy how this will be tested and maintained from now on for every release, e.g. a volunteer who takes over maintainership


### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS