### PR TITLE
fix: enable users without passwords to delete their accounts

### DIFF
--- a/lib/pages/settings_security/settings_security.dart
+++ b/lib/pages/settings_security/settings_security.dart
@@ -74,30 +74,21 @@ class SettingsSecurityController extends State<SettingsSecurity> {
     if (mxid == null || mxid.isEmpty || mxid != supposedMxid) {
       return;
     }
-    final input = await showTextInputDialog(
-      useRootNavigator: false,
+    final resp = await showFutureLoadingDialog(
       context: context,
-      title: L10n.of(context).pleaseEnterYourPassword,
-      okLabel: L10n.of(context).ok,
-      cancelLabel: L10n.of(context).cancel,
-      isDestructive: true,
-      obscureText: true,
-      hintText: '******',
-      minLines: 1,
-      maxLines: 1,
-    );
-    if (input == null) return;
-    await showFutureLoadingDialog(
-      context: context,
-      future: () => Matrix.of(context).client.deactivateAccount(
-        auth: AuthenticationPassword(
-          password: input,
-          identifier: AuthenticationUserIdentifier(
-            user: Matrix.of(context).client.userID!,
+      delay: false,
+      future: () =>
+          Matrix.of(context).client.uiaRequestBackground<IdServerUnbindResult?>(
+            (auth) => Matrix.of(context).client.deactivateAccount(auth: auth),
           ),
-        ),
-      ),
     );
+
+    if (!resp.isError) {
+      await showFutureLoadingDialog(
+        context: context,
+        future: () => Matrix.of(context).client.logout(),
+      );
+    }
   }
 
   Future<void> dehydrateAction() => Matrix.of(context).dehydrateAction(context);


### PR DESCRIPTION
Currently, users have to enter their passwords to delete their accounts. This means that users without passwords (i.e. users who use SSO for login) cannot delete their accounts without adding a password. This PR updates the account deletion function to use uiaRequestBackground to authenticate account deletion requests.

*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [x] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [x] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS