### PR TITLE
fix: android share screen 

### DIFF
--- a/lib/utils/show_scaffold_dialog.dart
+++ b/lib/utils/show_scaffold_dialog.dart
@@ -12,7 +12,7 @@ Future<T?> showScaffoldDialog<T>({
   required Widget Function(BuildContext context) builder,
 }) => showDialog<T>(
   context: context,
-  useSafeArea: false,
+  useSafeArea: true,
   builder: FluffyThemes.isColumnMode(context)
       ? (context) => Center(
           child: Container(


### PR DESCRIPTION
share screen previously was overlaping the navigation and notification bars

*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [x] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [x] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS