### PR TITLE
feat: Use per-room notification channels for custom sounds

### DIFF
--- a/lib/utils/push_helper.dart
+++ b/lib/utils/push_helper.dart
@@ -253,8 +253,8 @@ Future<void> _tryPushHelper(
       ?.createNotificationChannel(roomsChannel);
 
   final androidPlatformChannelSpecifics = AndroidNotificationDetails(
-    AppConfig.pushNotificationsChannelId,
-    l10n.incomingMessages,
+    event.room.id,
+    roomName,
     number: notification.counts?.unread,
     category: AndroidNotificationCategory.message,
     shortcutId: event.room.id,


### PR DESCRIPTION
## Summary

Route notifications through room-specific Android notification channels instead of a single global channel. This enables users to set custom notification sounds per room via **Android Settings → Apps → FluffyChat → Notifications**.

## Changes

- Use `event.room.id` and `roomName` in `AndroidNotificationDetails` instead of global `AppConfig.pushNotificationsChannelId`

## Context

The per-room channels were already being created (since commit a2e143c, Jun 2023) but notifications were routed through the global channel instead. This change simply uses the room-specific channel that's already being created at line 238-242.

## Question for maintainer

I noticed this functionality was implemented and reverted twice before:
- Dec 2022: `7806deb46` implemented, then `50dd924ec` reverted
- Apr 2023: `4a00f1faa` re-implemented with `event.room.id`
- Feb 2024: `dee9323d4` changed back to global channel (while adding shortcuts)

Was there a specific issue that caused the reverts? I'd like to understand before moving this out of draft.

## Test plan

1. Install the app and receive a notification from a room
2. Go to **Android Settings → Apps → FluffyChat → Notifications**
3. Channels should appear under "Direct Chats" and "Groups" with room names
4. Tap a room's channel to customize its notification sound
5. Verify the custom sound plays for subsequent notifications from that room