### PR TITLE
Fix aspect ratio of video player

### DIFF
--- a/lib/pages/image_viewer/video_player.dart
+++ b/lib/pages/image_viewer/video_player.dart
@@ -82,10 +82,6 @@ class EventVideoPlayerState extends State<EventVideoPlayer> {
 
       await videoPlayerController.initialize();
 
-      final infoMap = widget.event.content.tryGetMap<String, Object?>('info');
-      final videoWidth = infoMap?.tryGet<int>('w') ?? 400;
-      final videoHeight = infoMap?.tryGet<int>('h') ?? 300;
-
       // Create a ChewieController on top.
       setState(() {
         _chewieController = ChewieController(
@@ -94,7 +90,7 @@ class EventVideoPlayerState extends State<EventVideoPlayer> {
           autoPlay: true,
           autoInitialize: true,
           looping: true,
-          aspectRatio: videoHeight == 0 ? null : videoWidth / videoHeight,
+          aspectRatio: _videoPlayerController?.value.aspectRatio,
         );
       });
     } on IOException catch (e) {


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [x] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [x] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

The video player previously used the widget's size to determine aspect ratio, which caused it to get stretched often. I changed the code to use the video's own aspect ratio for the video player. This makes videos display correctly on my device.