### PR TITLE
fix: bump version number

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 # On version bump please also increase:
 # 1. The build number (for F-Droid)
 # 2. The version in /snap/snapcraft.yaml
-version: 2.4.0+3546
+version: 2.4.1+3547
 
 environment:
   sdk: ">=3.10.0 <4.0.0"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: fluffychat
 title: FluffyChat
 base: core24
-version: 2.4.0
+version: 2.4.1
 license: AGPL-3.0
 summary: The cutest messenger in the Matrix network
 description: |


### PR DESCRIPTION
increment the app version to match the git tag

This is a naive attempt to resolve #2509. If the CI auto-increments the tag this change would be insufficient, but I didn't notice that in the release pipeline. I'm happy to improve the PR with whatever I missed, I'm new to the project and would welcome feedback. 

- [x] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS