### PR TITLE
fix: Add app id to TileLayer user agent

### DIFF
--- a/lib/pages/chat/events/map_bubble.dart
+++ b/lib/pages/chat/events/map_bubble.dart
@@ -3,6 +3,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';
 
+import '../../../config/app_config.dart';
+
 class MapBubble extends StatelessWidget {
   final double latitude;
   final double longitude;
@@ -43,6 +45,7 @@ class MapBubble extends StatelessWidget {
                     minZoom: 0,
                     urlTemplate:
                         'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+                    userAgentPackageName: AppConfig.appId,
                     subdomains: const ['a', 'b', 'c'],
                   ),
                   MarkerLayer(


### PR DESCRIPTION
Identify the app in `TileLayer.userAgentPackageName` to comply with the [OpenStreetMap Tile Usage Policy](https://operations.osmfoundation.org/policies/tiles/). Closes #2570.

- [x] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [x] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [x] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS