### PR TITLE
fix: skip big-emote sizing for custom emotes

### DIFF
--- a/lib/pages/chat/events/message_content.dart
+++ b/lib/pages/chat/events/message_content.dart
@@ -258,6 +258,7 @@ class MessageContent extends StatelessWidget {
             }
 
             final bigEmotes =
+                !html.contains('mxc://') &&
                 event.onlyEmotes &&
                 event.numberEmotes > 0 &&
                 event.numberEmotes <= 3;


### PR DESCRIPTION
Custom emotes are `<img>` tags with a fixed size, so applying the 5× font scaling on top creates a large empty space above them.

`onlyEmotes` doesn't distinguish between Unicode and custom emotes, so checking for `mxc://` in the HTML body is used to skip the scaling for custom ones.

Fixes #1956.