### PR TITLE
fix: Fix formatting of messages with newlines

### DIFF
--- a/lib/utils/client_manager.dart
+++ b/lib/utils/client_manager.dart
@@ -138,7 +138,6 @@ abstract class ClientManager {
             (share) => share.name == shareKeysWith,
           ) ??
           ShareKeysWith.all,
-      convertLinebreaksInFormatting: false,
       onSoftLogout: enableSoftLogout
           ? (client) => client.refreshAccessToken()
           : null,


### PR DESCRIPTION
Newlines were previously not formatted correctly in HTML/markdown messages.

This fixes #2393.

#### Cause of the issue
Formatting is of newlines is implemented in the matrix-dart-sdk, but was explicitly disabled when creating the matrix Client object.

#### Description of the fix
This fixes formatting by removing the parameter from the client config, causing the client to follow the expected, default behavior. The formatted message is then rendered correctly in both FluffyChat and Element.

When sending a message like:
> Wordle 1'717 5/6
> 
> ⬛🟨🟨⬛⬛
> ⬛⬛⬛⬛🟨
> 🟨⬛⬛🟨🟨
> ⬛🟩🟨🟨⬛
> 🟩🟩🟩🟩🟩

Some newline characters were not replaced with the proper HTML `<br>` tag. Without this change, the message would be encoded as:
```json
"content": {
    "body": "Wordle 1'717 5/6\n\n⬛🟨🟨⬛⬛\n⬛⬛⬛⬛🟨\n🟨⬛⬛🟨🟨\n⬛🟩🟨🟨⬛\n🟩🟩🟩🟩🟩",
    "format": "org.matrix.custom.html",
    "formatted_body": "<p>Wordle 1'717 5/6</p>\n<p>⬛🟨🟨⬛⬛\n⬛⬛⬛⬛🟨\n🟨⬛⬛🟨🟨\n⬛🟩🟨🟨⬛\n🟩🟩🟩🟩🟩</p>",
    "msgtype": "m.text"
  }
```

`\n` is not rendered as a newline in Element. With this change, these characters are correctly replaced and the message is now encoded as:
```json
"content": {
    "body": "Wordle 1'717 5/6\n\n⬛🟨🟨⬛⬛\n⬛⬛⬛⬛🟨\n🟨⬛⬛🟨🟨\n⬛🟩🟨🟨⬛\n🟩🟩🟩🟩🟩",
    "format": "org.matrix.custom.html",
    "formatted_body": "<p>Wordle 1'717 5/6</p><p>⬛🟨🟨⬛⬛<br/>⬛⬛⬛⬛🟨<br/>🟨⬛⬛🟨🟨<br/>⬛🟩🟨🟨⬛<br/>🟩🟩🟩🟩🟩</p>",
    "msgtype": "m.text"
  }
```

New messages are now rendered correctly in both clients in the same way.

**Warning:** The encoded `formatted_body` value still does not match what Element produces in all cases. In a message sent from Element, newlines are encoded as `<br/>\n`. However, it's not clear whether this is expected. The [Matrix spec](https://spec.matrix.org/v1.17/client-server-api/#mroommessage-msgtypes) does not seem to specify this.

#### Backwards Compatibility
This only affects outgoing new messages, both old wrongly formatted messages and new messages are rendered correctly in FluffyChat. New messages are now also correctly formatted in other clients.


- [X] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [X] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

I also confirmed that messages are rendered correctly (both old and new HTML) on the Android app.
Note that test cases for this exist in the matrix-dart-sdk: https://github.com/famedly/matrix-dart-sdk/blob/1ca7ca45c81d2b0fd5d7362df1f3f002782d8e85/test/markdown_test.dart#L73
In all test cases there, the flag is set to the default `true `.