### PR TITLE
chore: Remove web notification custom sound

### DIFF
--- a/lib/widgets/local_notifications_extension.dart
+++ b/lib/widgets/local_notifications_extension.dart
@@ -18,10 +18,6 @@ import 'package:fluffychat/widgets/fluffy_chat_app.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 
 extension LocalNotificationsExtension on MatrixState {
-  static final html.AudioElement _audioPlayer = html.AudioElement()
-    ..src = 'assets/assets/sounds/notification.ogg'
-    ..load();
-
   Future<void> showLocalNotification(Event event) async {
     final roomId = event.room.id;
     if (activeRoomId == roomId) {
@@ -73,8 +69,6 @@ extension LocalNotificationsExtension on MatrixState {
               method: thumbnailMethod,
             );
       }
-
-      _audioPlayer.play();
 
       html.Notification(
         title,


### PR DESCRIPTION
Sound is now played on macOS and Windows by default. On some Linux distro it may differ but there it should be possible to configure it.

Also on Linux there is the native version anyway.

*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS