### PR TITLE
Fix regression in Swedish translation

### DIFF
--- a/lib/l10n/intl_sv.arb
+++ b/lib/l10n/intl_sv.arb
@@ -2333,7 +2333,7 @@
     "stickers": "Klistermärken",
     "discover": "Upptäck",
     "ignoreUser": "Ignorera användare",
-    "aboutHomeserver": "Om{homeserver}",
+    "aboutHomeserver": "Om {homeserver}",
     "@aboutHomeserver": {
         "type": "String",
         "placeholders": {


### PR DESCRIPTION
This fixes a regression in the Swedish translation that I noticed with the recent update to version 1.5.1 of the android app.