### PR TITLE
feat: unpin events directly from pinned events menu

### DIFF
--- a/lib/pages/chat/pinned_events.dart
+++ b/lib/pages/chat/pinned_events.dart
@@ -4,7 +4,6 @@ import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pages/chat/chat.dart';
 import 'package:fluffychat/pages/chat/chat_app_bar_list_tile.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/matrix_locals.dart';
-import 'package:fluffychat/widgets/adaptive_dialogs/show_modal_action_popup.dart';
 import 'package:fluffychat/widgets/future_loading_dialog.dart';
 import 'package:flutter/material.dart';
 import 'package:matrix/matrix.dart';
@@ -28,30 +27,72 @@ class PinnedEvents extends StatelessWidget {
     if (events == null) return;
     if (!context.mounted) return;
 
-    final eventId = events.length == 1
-        ? events.single?.eventId
-        : await showModalActionPopup<String>(
-            context: context,
-            title: l10n.pin,
-            cancelLabel: l10n.cancel,
-            actions: events
-                .map(
-                  (event) => AdaptiveModalAction(
-                    value: event?.eventId ?? '',
-                    icon: const Icon(Icons.push_pin_outlined),
-                    label:
-                        event?.calcLocalizedBodyFallback(
-                          MatrixLocals(l10n),
-                          withSenderNamePrefix: true,
-                          hideReply: true,
-                        ) ??
-                        'UNKNOWN',
-                  ),
-                )
-                .toList(),
-          );
+    if (events.length == 1) {
+      final event = events.single;
+      if (event != null) controller.scrollToEventId(event.eventId);
+      return;
+    }
 
-    if (eventId != null) controller.scrollToEventId(eventId);
+    final canUnpin =
+        controller.room.canSendEvent(EventTypes.RoomPinnedEvents);
+
+    final eventId = await showModalBottomSheet<String>(
+      context: context,
+      isScrollControlled: true,
+      clipBehavior: Clip.hardEdge,
+      constraints: BoxConstraints(
+        maxWidth: 512,
+        maxHeight: MediaQuery.sizeOf(context).height - 32,
+      ),
+      builder: (context) => ListView(
+        shrinkWrap: true,
+        children: [
+          ListTile(
+            title: Text(
+              l10n.pin,
+              style: Theme.of(context).textTheme.labelSmall,
+            ),
+          ),
+          const Divider(height: 1),
+          ...events.map(
+            (event) => ListTile(
+              leading: canUnpin
+                  ? IconButton(
+                      icon: const Icon(Icons.push_pin),
+                      tooltip: l10n.unpin,
+                      onPressed: () {
+                        Navigator.of(context).pop<String>();
+                        if (event != null) {
+                          controller.unpinEvent(event.eventId);
+                        }
+                      },
+                    )
+                  : const Icon(Icons.push_pin_outlined),
+              title: Text(
+                event?.calcLocalizedBodyFallback(
+                      MatrixLocals(l10n),
+                      withSenderNamePrefix: true,
+                      hideReply: true,
+                    ) ??
+                    'UNKNOWN',
+                maxLines: 1,
+              ),
+              onTap: () =>
+                  Navigator.of(context).pop<String>(event?.eventId ?? ''),
+            ),
+          ),
+          const Divider(height: 1),
+          ListTile(
+            title: Text(l10n.cancel),
+            onTap: () => Navigator.of(context).pop<String>(),
+          ),
+        ],
+      ),
+    );
+
+    if (eventId != null && eventId.isNotEmpty) {
+      controller.scrollToEventId(eventId);
+    }
   }
 
   @override


### PR DESCRIPTION
Replaces the action popup with a bottom sheet that shows unpin buttons next to each pinned event, which lets users to unpin without navigating to the event first.

*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [X] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [X] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS