### PR TITLE
feat: right-click opens context menu on chat list items

### DIFF
--- a/lib/pages/chat_list/chat_list_body.dart
+++ b/lib/pages/chat_list/chat_list_body.dart
@@ -15,6 +15,7 @@ import 'package:matrix/matrix.dart';
 
 import '../../config/themes.dart';
 import '../../widgets/adaptive_dialogs/user_dialog.dart';
+import '../../widgets/member_actions_popup_menu_button.dart';
 import '../../widgets/matrix.dart';
 import 'chat_list_header.dart';
 
@@ -240,6 +241,19 @@ class ChatListViewBody extends StatelessWidget {
                       onTap: () => controller.onChatTap(room),
                       onLongPress: (context) =>
                           controller.chatContextAction(room, context, space),
+                      onSecondaryTap: (context) {
+                        final directChatMatrixId = room.directChatMatrixID;
+                        if (directChatMatrixId != null) {
+                          showMemberActionsPopupMenu(
+                            context: context,
+                            user: room.unsafeGetUserFromMemoryOrFallback(
+                              directChatMatrixId,
+                            ),
+                          );
+                        } else {
+                          controller.chatContextAction(room, context, space);
+                        }
+                      },
                       activeChat: controller.activeChat == room.id,
                     );
                   },

--- a/lib/pages/chat_list/chat_list_item.dart
+++ b/lib/pages/chat_list/chat_list_item.dart
@@ -18,6 +18,7 @@ class ChatListItem extends StatelessWidget {
   final Room? space;
   final bool activeChat;
   final void Function(BuildContext context)? onLongPress;
+  final void Function(BuildContext context)? onSecondaryTap;
   final void Function()? onForget;
   final void Function() onTap;
   final String? filter;
@@ -27,6 +28,7 @@ class ChatListItem extends StatelessWidget {
     this.activeChat = false,
     required this.onTap,
     this.onLongPress,
+    this.onSecondaryTap,
     this.onForget,
     this.filter,
     this.space,
@@ -69,7 +71,11 @@ class ChatListItem extends StatelessWidget {
         child: FutureBuilder(
           future: room.name.isEmpty ? room.loadHeroUsers() : null,
           builder: (context, _) => HoverBuilder(
-            builder: (context, listTileHovered) => ListTile(
+            builder: (context, listTileHovered) => GestureDetector(
+              onSecondaryTapUp: onSecondaryTap != null
+                  ? (_) => onSecondaryTap!.call(context)
+                  : null,
+              child: ListTile(
               visualDensity: const VisualDensity(vertical: -0.5),
               contentPadding: const EdgeInsets.symmetric(horizontal: 8),
               onLongPress: () => onLongPress?.call(context),
@@ -391,6 +397,7 @@ class ChatListItem extends StatelessWidget {
                       icon: const Icon(Icons.delete_outlined),
                       onPressed: onForget,
                     ),
+            ),
             ),
           ),
         ),


### PR DESCRIPTION
Adds right-click support to chat list items. For direct chats, shows the member actions popup menu. For group chats, falls back to the standard chat context action

*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [X] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [X] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS