### PR TITLE
feat: show sticker body text in chat list preview

### DIFF
--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -1673,7 +1673,7 @@
             }
         }
     },
-    "sentAStickerBody": "🗒️ {username} sent {stickerBody}",
+    "sentAStickerBody": "🗒️ {username} sent sticker {stickerBody}",
     "@sentAStickerBody": {
         "type": "String",
         "placeholders": {

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -1673,6 +1673,18 @@
             }
         }
     },
+    "sentAStickerBody": "🗒️ {username} sent {stickerBody}",
+    "@sentAStickerBody": {
+        "type": "String",
+        "placeholders": {
+            "username": {
+                "type": "String"
+            },
+            "stickerBody": {
+                "type": "String"
+            }
+        }
+    },
     "sentAVideo": "🎥 {username} sent a video",
     "@sentAVideo": {
         "type": "String",

--- a/lib/pages/chat_list/chat_list_item.dart
+++ b/lib/pages/chat_list/chat_list_item.dart
@@ -310,20 +310,7 @@ class ChatListItem extends StatelessWidget {
                             key: ValueKey(
                               '${lastEvent?.eventId}_${lastEvent?.type}_${lastEvent?.redacted}',
                             ),
-                            future: lastEvent?.type == EventTypes.Sticker
-                                ? Future.value(
-                                    L10n.of(context).sentAStickerBody(
-                                      lastEvent!
-                                          .senderFromMemoryOrFallback
-                                          .calcDisplayname(
-                                            i18n: MatrixLocals(
-                                              L10n.of(context),
-                                            ),
-                                          ),
-                                      lastEvent.body,
-                                    ),
-                                  )
-                                : needLastEventSender
+                            future: needLastEventSender
                                 ? lastEvent.calcLocalizedBody(
                                     MatrixLocals(L10n.of(context)),
                                     hideReply: true,
@@ -336,18 +323,7 @@ class ChatListItem extends StatelessWidget {
                                             room.lastEvent?.senderId),
                                   )
                                 : null,
-                            initialData: lastEvent?.type == EventTypes.Sticker
-                                ? L10n.of(context).sentAStickerBody(
-                                    lastEvent!
-                                        .senderFromMemoryOrFallback
-                                        .calcDisplayname(
-                                          i18n: MatrixLocals(
-                                            L10n.of(context),
-                                          ),
-                                        ),
-                                    lastEvent.body,
-                                  )
-                                : lastEvent?.calcLocalizedBodyFallback(
+                            initialData: lastEvent?.calcLocalizedBodyFallback(
                               MatrixLocals(L10n.of(context)),
                               hideReply: true,
                               hideEdit: true,

--- a/lib/pages/chat_list/chat_list_item.dart
+++ b/lib/pages/chat_list/chat_list_item.dart
@@ -310,7 +310,20 @@ class ChatListItem extends StatelessWidget {
                             key: ValueKey(
                               '${lastEvent?.eventId}_${lastEvent?.type}_${lastEvent?.redacted}',
                             ),
-                            future: needLastEventSender
+                            future: lastEvent?.type == EventTypes.Sticker
+                                ? Future.value(
+                                    L10n.of(context).sentAStickerBody(
+                                      lastEvent!
+                                          .senderFromMemoryOrFallback
+                                          .calcDisplayname(
+                                            i18n: MatrixLocals(
+                                              L10n.of(context),
+                                            ),
+                                          ),
+                                      lastEvent.body,
+                                    ),
+                                  )
+                                : needLastEventSender
                                 ? lastEvent.calcLocalizedBody(
                                     MatrixLocals(L10n.of(context)),
                                     hideReply: true,
@@ -323,7 +336,18 @@ class ChatListItem extends StatelessWidget {
                                             room.lastEvent?.senderId),
                                   )
                                 : null,
-                            initialData: lastEvent?.calcLocalizedBodyFallback(
+                            initialData: lastEvent?.type == EventTypes.Sticker
+                                ? L10n.of(context).sentAStickerBody(
+                                    lastEvent!
+                                        .senderFromMemoryOrFallback
+                                        .calcDisplayname(
+                                          i18n: MatrixLocals(
+                                            L10n.of(context),
+                                          ),
+                                        ),
+                                    lastEvent.body,
+                                  )
+                                : lastEvent?.calcLocalizedBodyFallback(
                               MatrixLocals(L10n.of(context)),
                               hideReply: true,
                               hideEdit: true,

--- a/lib/utils/matrix_sdk_extensions/matrix_locals.dart
+++ b/lib/utils/matrix_sdk_extensions/matrix_locals.dart
@@ -5,7 +5,26 @@ import 'package:matrix/matrix.dart';
 class MatrixLocals extends MatrixLocalizations {
   final L10n l10n;
 
-  MatrixLocals(this.l10n);
+  static bool _stickerLocalizationPatched = false;
+
+  /// Patches the SDK's sticker localization to include the sticker body text.
+  static void _patchStickerLocalization() {
+    if (_stickerLocalizationPatched) return;
+    _stickerLocalizationPatched = true;
+    EventLocalizations.localizationsMap[EventTypes.Sticker] =
+        (event, i18n, body) {
+      final senderName =
+          event.senderFromMemoryOrFallback.calcDisplayname(i18n: i18n);
+      if (i18n is MatrixLocals && body.isNotEmpty) {
+        return i18n.l10n.sentAStickerBody(senderName, body);
+      }
+      return i18n.sentASticker(senderName);
+    };
+  }
+
+  MatrixLocals(this.l10n) {
+    _patchStickerLocalization();
+  }
 
   @override
   String acceptedTheInvitation(String targetName) {


### PR DESCRIPTION
Displays the sticker name/body in the chat list subtitle instead of a generic message, so users can see which sticker was sent. I also changed the emoji to the...closest thing I could find to a sticky note (please let me know if this wasn't a good choice).

*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [X] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [X] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS