### PR TITLE
added preview for escaped chars

### DIFF
--- a/lib/pages/chat/events/reply_content.dart
+++ b/lib/pages/chat/events/reply_content.dart
@@ -1,5 +1,6 @@
 import 'package:fluffychat/config/setting_keys.dart';
 import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/utils/matrix_sdk_extensions/event_plain_text_body.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/matrix_locals.dart';
 import 'package:flutter/material.dart';
 import 'package:matrix/matrix.dart';
@@ -76,11 +77,10 @@ class ReplyContent extends StatelessWidget {
                   },
                 ),
                 Text(
-                  displayEvent.calcLocalizedBodyFallback(
+                  displayEvent.calcLocalizedBodyFallbackFixed(
                     MatrixLocals(L10n.of(context)),
                     withSenderNamePrefix: false,
                     hideReply: true,
-                    plaintextBody: true,
                   ),
                   overflow: TextOverflow.ellipsis,
                   maxLines: 1,

--- a/lib/pages/chat_list/chat_list_item.dart
+++ b/lib/pages/chat_list/chat_list_item.dart
@@ -1,6 +1,7 @@
 import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pages/chat_list/unread_bubble.dart';
+import 'package:fluffychat/utils/matrix_sdk_extensions/event_plain_text_body.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/matrix_locals.dart';
 import 'package:fluffychat/utils/room_status_extension.dart';
 import 'package:fluffychat/widgets/adaptive_dialogs/show_ok_cancel_alert_dialog.dart';
@@ -311,24 +312,21 @@ class ChatListItem extends StatelessWidget {
                               '${lastEvent?.eventId}_${lastEvent?.type}_${lastEvent?.redacted}',
                             ),
                             future: needLastEventSender
-                                ? lastEvent.calcLocalizedBody(
+                                ? lastEvent.calcLocalizedBodyFixed(
                                     MatrixLocals(L10n.of(context)),
                                     hideReply: true,
                                     hideEdit: true,
-                                    plaintextBody: true,
-                                    removeMarkdown: true,
                                     withSenderNamePrefix:
                                         (!isDirectChat ||
                                         directChatMatrixId !=
                                             room.lastEvent?.senderId),
                                   )
                                 : null,
-                            initialData: lastEvent?.calcLocalizedBodyFallback(
+                            initialData:
+                                lastEvent?.calcLocalizedBodyFallbackFixed(
                               MatrixLocals(L10n.of(context)),
                               hideReply: true,
                               hideEdit: true,
-                              plaintextBody: true,
-                              removeMarkdown: true,
                               withSenderNamePrefix:
                                   (!isDirectChat ||
                                   directChatMatrixId !=

--- a/lib/pages/chat_search/chat_search_message_tab.dart
+++ b/lib/pages/chat_search/chat_search_message_tab.dart
@@ -1,6 +1,7 @@
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pages/chat_search/search_footer.dart';
 import 'package:fluffychat/utils/date_time_extension.dart';
+import 'package:fluffychat/utils/matrix_sdk_extensions/event_plain_text_body.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/matrix_locals.dart';
 import 'package:fluffychat/utils/url_launcher.dart';
 import 'package:fluffychat/widgets/avatar.dart';
@@ -122,10 +123,10 @@ class _MessageSearchResultListTile extends StatelessWidget {
         ),
         onOpen: (url) => UrlLauncher(context, url.url).launchUrl(),
         text: event
-            .calcLocalizedBodyFallback(
-              plaintextBody: true,
-              removeMarkdown: true,
+            .calcLocalizedBodyFallbackFixed(
               MatrixLocals(L10n.of(context)),
+              hideReply: true,
+              hideEdit: true,
             )
             .trim(),
         maxLines: 7,

--- a/lib/utils/matrix_sdk_extensions/event_plain_text_body.dart
+++ b/lib/utils/matrix_sdk_extensions/event_plain_text_body.dart
@@ -1,0 +1,126 @@
+import 'package:html/parser.dart' as html_parser;
+import 'package:matrix/matrix.dart';
+
+extension PlainTextBody on Event {
+  /// Whether the effective content (considering edits) has HTML formatted_body.
+  bool _effectiveContentHasHtml({required bool hideEdit}) {
+    final newContent = content.tryGetMap<String, Object?>('m.new_content');
+    if (hideEdit &&
+        relationshipType == RelationshipTypes.edit &&
+        newContent != null) {
+      return newContent['format'] == 'org.matrix.custom.html' &&
+          (newContent.tryGet<String>('formatted_body') ?? '').isNotEmpty;
+    }
+    return content['format'] == 'org.matrix.custom.html' &&
+        formattedText.isNotEmpty;
+  }
+
+  /// Extract plain text directly from the effective HTML content,
+  /// bypassing the SDK's markdown round-trip that corrupts escaped characters.
+  String _plainTextFromHtml({
+    required bool hideEdit,
+    required bool hideReply,
+  }) {
+    String html;
+    final newContent = content.tryGetMap<String, Object?>('m.new_content');
+    if (hideEdit &&
+        relationshipType == RelationshipTypes.edit &&
+        newContent != null) {
+      html = newContent.tryGet<String>('formatted_body') ?? '';
+    } else {
+      html = formattedText;
+    }
+
+    if (hideReply) {
+      html = html.replaceAll(
+        RegExp(
+          '<mx-reply>.*</mx-reply>',
+          caseSensitive: false,
+          multiLine: false,
+          dotAll: true,
+        ),
+        '',
+      );
+    }
+
+    return html_parser.parseFragment(html).text?.trim() ?? body;
+  }
+
+  /// Like [calcLocalizedBodyFallback] with `plaintextBody: true` and
+  /// `removeMarkdown: true`, but avoids the SDK's double-processing bug
+  /// where HTML→plaintext→markdown→plaintext corrupts escaped characters.
+  String calcLocalizedBodyFallbackFixed(
+    MatrixLocalizations i18n, {
+    bool withSenderNamePrefix = false,
+    bool hideReply = false,
+    bool hideEdit = false,
+  }) {
+    if (redacted) {
+      return calcLocalizedBodyFallback(
+        i18n,
+        withSenderNamePrefix: withSenderNamePrefix,
+        hideReply: hideReply,
+        hideEdit: hideEdit,
+        plaintextBody: true,
+        removeMarkdown: true,
+      );
+    }
+
+    final isTextMessage = type == EventTypes.Message &&
+        Event.textOnlyMessageTypes.contains(messageType);
+
+    if (isTextMessage && _effectiveContentHasHtml(hideEdit: hideEdit)) {
+      var plainText = _plainTextFromHtml(
+        hideEdit: hideEdit,
+        hideReply: hideReply,
+      );
+
+      if (messageType == MessageTypes.Emote) {
+        plainText = '* $plainText';
+      }
+
+      if (withSenderNamePrefix) {
+        final senderNameOrYou = senderId == room.client.userID
+            ? i18n.you
+            : senderFromMemoryOrFallback.calcDisplayname(i18n: i18n);
+        plainText = '$senderNameOrYou: $plainText';
+      }
+
+      return plainText;
+    }
+
+    return calcLocalizedBodyFallback(
+      i18n,
+      withSenderNamePrefix: withSenderNamePrefix,
+      hideReply: hideReply,
+      hideEdit: hideEdit,
+      plaintextBody: true,
+      removeMarkdown: true,
+    );
+  }
+
+  /// Like [calcLocalizedBody] with `plaintextBody: true` and
+  /// `removeMarkdown: true`, but avoids the SDK's double-processing bug.
+  Future<String> calcLocalizedBodyFixed(
+    MatrixLocalizations i18n, {
+    bool withSenderNamePrefix = false,
+    bool hideReply = false,
+    bool hideEdit = false,
+  }) async {
+    if (redacted) {
+      await redactedBecause?.fetchSenderUser();
+    }
+
+    if (withSenderNamePrefix &&
+        (type == EventTypes.Message || type.contains(EventTypes.Encrypted))) {
+      await fetchSenderUser();
+    }
+
+    return calcLocalizedBodyFallbackFixed(
+      i18n,
+      withSenderNamePrefix: withSenderNamePrefix,
+      hideReply: hideReply,
+      hideEdit: hideEdit,
+    );
+  }
+}

--- a/lib/utils/push_helper.dart
+++ b/lib/utils/push_helper.dart
@@ -7,6 +7,7 @@ import 'package:fluffychat/config/setting_keys.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/utils/client_download_content_extension.dart';
 import 'package:fluffychat/utils/client_manager.dart';
+import 'package:fluffychat/utils/matrix_sdk_extensions/event_plain_text_body.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/matrix_locals.dart';
 import 'package:fluffychat/utils/notification_background_handler.dart';
 import 'package:fluffychat/utils/platform_infos.dart';
@@ -145,13 +146,11 @@ Future<void> _tryPushHelper(
   // Calculate the body
   final body = event.type == EventTypes.Encrypted
       ? l10n.newMessageInFluffyChat
-      : await event.calcLocalizedBody(
+      : await event.calcLocalizedBodyFixed(
           matrixLocals,
-          plaintextBody: true,
           withSenderNamePrefix: false,
           hideReply: true,
           hideEdit: true,
-          removeMarkdown: true,
         );
 
   // The person object for the android message style notification

--- a/lib/widgets/local_notifications_extension.dart
+++ b/lib/widgets/local_notifications_extension.dart
@@ -5,6 +5,7 @@ import 'package:desktop_notifications/desktop_notifications.dart';
 import 'package:fluffychat/config/setting_keys.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/utils/client_download_content_extension.dart';
+import 'package:fluffychat/utils/matrix_sdk_extensions/event_plain_text_body.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/matrix_locals.dart';
 import 'package:fluffychat/utils/push_helper.dart';
 import 'package:fluffychat/widgets/fluffy_chat_app.dart';
@@ -32,15 +33,13 @@ extension LocalNotificationsExtension on MatrixState {
     final title = event.room.getLocalizedDisplayname(
       MatrixLocals(L10n.of(context)),
     );
-    final body = await event.calcLocalizedBody(
+    final body = await event.calcLocalizedBodyFixed(
       MatrixLocals(L10n.of(context)),
       withSenderNamePrefix:
           !event.room.isDirectChat ||
           event.room.lastEvent?.senderId == client.userID,
-      plaintextBody: true,
       hideReply: true,
       hideEdit: true,
-      removeMarkdown: true,
     );
 
     if (kIsWeb) {


### PR DESCRIPTION
for example, `\>~<` previously previewed as `~<` and should now preview as `>~<`

*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [X] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [X] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS