### PR TITLE
feat(chat): make messagePreviewMaxLines configurable, with default 128

### DIFF
--- a/config.sample.json
+++ b/config.sample.json
@@ -12,6 +12,7 @@
   "audioRecordingSamplingRate": 44100,
   "renderHtml": true,
   "fontSizeFactor": 1,
+  "messagePreviewMaxLines": 128,
   "hideRedactedEvents": false,
   "hideUnknownEvents": true,
   "separateChatTypes": false,

--- a/lib/config/setting_keys.dart
+++ b/lib/config/setting_keys.dart
@@ -9,6 +9,9 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 enum AppSettings<T> {
   textMessageMaxLength<int>('textMessageMaxLength', 16384),
+
+  /// Max lines for unselected HTML/text bubbles; 0 = unlimited (no fade).
+  messagePreviewMaxLines<int>('chat.fluffy.message_preview_max_lines', 128),
   audioRecordingNumChannels<int>('audioRecordingNumChannels', 1),
   audioRecordingAutoGain<bool>('audioRecordingAutoGain', true),
   audioRecordingEchoCancel<bool>('audioRecordingEchoCancel', false),

--- a/lib/pages/chat/events/html_message.dart
+++ b/lib/pages/chat/events/html_message.dart
@@ -1,4 +1,5 @@
 import 'package:collection/collection.dart';
+import 'package:fluffychat/config/setting_keys.dart';
 import 'package:fluffychat/utils/code_highlight_theme.dart';
 import 'package:fluffychat/utils/event_checkbox_extension.dart';
 import 'package:fluffychat/widgets/avatar.dart';
@@ -509,11 +510,15 @@ class HtmlMessage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final element = parser.parse(html).body ?? dom.Element.html('');
+    final configuredMaxLines = AppSettings.messagePreviewMaxLines.value;
+    final maxLines = !limitHeight || configuredMaxLines <= 0
+        ? null
+        : configuredMaxLines;
     return Text.rich(
       _renderHtml(element, context),
       style: TextStyle(fontSize: fontSize, color: textColor),
-      maxLines: limitHeight ? 64 : null,
-      overflow: TextOverflow.fade,
+      maxLines: maxLines,
+      overflow: maxLines == null ? TextOverflow.visible : TextOverflow.fade,
       selectionColor: textColor.withAlpha(128),
     );
   }


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [x] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [x] Android
- [x] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

# Tests
999 words lorem ipsum with 10 and 500 lines 

## Android

### 10 lines
<img width="1080" height="2400" alt="android-10" src="https://github.com/user-attachments/assets/fbc65f40-4805-4c0a-a14a-0287f46c6637" />
<img width="1080" height="2400" alt="android-10-msg" src="https://github.com/user-attachments/assets/80db4c1b-0731-48eb-b57b-72fe7b7bffae" />

###  500 lines
<img width="1080" height="2400" alt="android-500" src="https://github.com/user-attachments/assets/92b01646-96fa-4033-b858-38563a16fdd5" />
<img width="1080" height="2400" alt="android-500-msg" src="https://github.com/user-attachments/assets/c78245c1-5533-4d4e-af56-460369e650c8" />

## ios

### 10 lines
<img width="1290" height="2796" alt="ss-10" src="https://github.com/user-attachments/assets/0366f961-ebc2-49fe-bcfc-54ec107242f6" />
<img width="1290" height="2796" alt="ss-10-text" src="https://github.com/user-attachments/assets/26373edf-55c5-4dd2-a6e8-2f3111c45dcd" />

### 500 lines
<img width="1290" height="2796" alt="ss-500" src="https://github.com/user-attachments/assets/7e8e52c5-0349-46da-a63f-e945558e82a0" />
<img width="1290" height="2796" alt="ss-500-text" src="https://github.com/user-attachments/assets/032a814c-7fb6-452d-bef9-4f9144b80866" />
