### PR TITLE
fix: add prepare-web.sh support for both python and go yq versions

### DIFF
--- a/scripts/prepare-web.sh
+++ b/scripts/prepare-web.sh
@@ -2,7 +2,7 @@
 
 # Compile Vodozemac for web
 version=$(yq ".dependencies.flutter_vodozemac" < pubspec.yaml)
-version=$(expr "$version" : '\^*\(.*\)')
+version=$(printf "%s" "$version" | tr -d '"^')
 git clone https://github.com/famedly/dart-vodozemac.git -b ${version} .vodozemac
 cd .vodozemac
 cargo install flutter_rust_bridge_codegen
@@ -16,7 +16,7 @@ dart compile js ./web/native_executor.dart -o ./web/native_executor.js -m
 
 # Download native_imaging for web:
 version=$(yq ".dependencies.native_imaging" < pubspec.yaml)
-version=$(expr "$version" : '\^*\(.*\)')
+version=$(printf "%s" "$version" | tr -d '"^')
 curl -L "https://github.com/famedly/dart_native_imaging/releases/download/v${version}/native_imaging.zip" > native_imaging.zip
 unzip native_imaging.zip
 mv js/* web/


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [x] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [x] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

## Explanation
Different Linux distros provide different *yq* implementations. There are two primary ones: the Golang implementation, which is more popular, and the Python implementation. Some distros, such Linux Mint (as well as Ubuntu, Debian and potentially a few others), still use the Python one, which is a wrapper around *jq*.

The main difference between them is that the former strips double quotes (**""**), while the latter preserves them resulting in the script failing with the Python implementation, where **""** persist, thus **^** does not get removed, which results in trying to fetch the version as "^0.5.0", for example, instead of simply the correct 0.5.0.
This behavior can be modified using *-r* flag in Python implementation, which the Golang version does not support, so that could not be used here. Therefore, I opted to strip both **""** and **^** using *tr* piping and *printf*. I then tested the script with both *yq* versions installed (separately, of course) and it seemed to work in both cases.