### PR TITLE
Match system typography on macOS

### DIFF
--- a/lib/config/app_config.dart
+++ b/lib/config/app_config.dart
@@ -1,4 +1,7 @@
+import 'dart:io' show Platform;
 import 'dart:ui';
+
+import 'package:flutter/foundation.dart';
 
 abstract class AppConfig {
   // Const and final configuration values (immutable)
@@ -7,7 +10,20 @@ abstract class AppConfig {
   static const Color secondaryColor = Color(0xFF41a2bc);
 
   static const Color chatColor = primaryColor;
-  static const double messageFontSize = 16.0;
+  // Chat body base size. macOS native chat apps (Telegram, Messages, Mail)
+  // render body around 14pt, noticeably tighter than Material 3's 16sp.
+  // Everywhere else we keep Material/HIG defaults (16sp on Android,
+  // ~17pt on iOS via Dynamic Type).
+  static final double messageFontSize = (!kIsWeb && Platform.isMacOS)
+      ? 14.0
+      : 16.0;
+
+  // Line-height for message body. macOS/SF Pro feels natural at 1.25×,
+  // which is tighter than the default Material/font leading. On other
+  // platforms we leave it null so each font uses its own intrinsic leading.
+  static final double? messageLineHeight = (!kIsWeb && Platform.isMacOS)
+      ? 1.25
+      : null;
   static const bool allowOtherHomeservers = true;
   static const bool enableRegistration = true;
   static const bool hideTypingUsernames = false;

--- a/lib/config/app_font_size.dart
+++ b/lib/config/app_font_size.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/widgets.dart';
+
+import 'setting_keys.dart';
+
+/// Listenable mirror of [AppSettings.fontSizeFactor] so the global
+/// [MediaQuery.textScaler] wrapper rebuilds when the slider moves.
+final ValueNotifier<double> fontSizeFactorNotifier = ValueNotifier<double>(
+  AppSettings.fontSizeFactor.value,
+);
+
+/// Multiplies an inner [TextScaler] by a linear factor, preserving
+/// non-linear OS behavior (e.g. iOS Dynamic Type) on top of the user
+/// font-size preference.
+@immutable
+class ScaledTextScaler extends TextScaler {
+  const ScaledTextScaler(this.inner, this.factor);
+
+  final TextScaler inner;
+  final double factor;
+
+  @override
+  double scale(double fontSize) => inner.scale(fontSize) * factor;
+
+  @override
+  // ignore: deprecated_member_use
+  double get textScaleFactor => inner.textScaleFactor * factor;
+
+  @override
+  bool operator ==(Object other) =>
+      other is ScaledTextScaler &&
+      other.inner == inner &&
+      other.factor == factor;
+
+  @override
+  int get hashCode => Object.hash(inner, factor);
+}

--- a/lib/config/themes.dart
+++ b/lib/config/themes.dart
@@ -1,5 +1,6 @@
 import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/config/setting_keys.dart';
+import 'package:fluffychat/utils/platform_infos.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
@@ -45,11 +46,17 @@ abstract class FluffyThemes {
       seedColor: seed ?? Color(AppSettings.colorSchemeSeedInt.value),
     );
     final isColumnMode = FluffyThemes.isColumnMode(context);
+    final isApple = PlatformInfos.isCupertinoStyle;
     return ThemeData(
       visualDensity: VisualDensity.standard,
       useMaterial3: true,
       brightness: brightness,
       colorScheme: colorScheme,
+      // SF Pro Text on Apple platforms; Material default elsewhere.
+      // 'CupertinoSystemText' is resolved by the Flutter engine to
+      // .AppleSystemUIFont, with the Display↔Text split handled natively
+      // at the 20pt boundary.
+      fontFamily: isApple ? 'CupertinoSystemText' : null,
       dividerColor: brightness == Brightness.dark
           ? colorScheme.surfaceContainerHighest
           : colorScheme.surfaceContainer,
@@ -132,6 +139,63 @@ abstract class FluffyThemes {
           padding: const EdgeInsets.all(16),
           textStyle: const TextStyle(fontSize: 16),
         ),
+      ),
+      textTheme: isApple
+          ? _appleTextTheme(null, isIOS: PlatformInfos.isIOS)
+          : null,
+    );
+  }
+
+  /// Applies Apple HIG letter-spacing to Material 3 text styles so SF Pro
+  /// renders with native tracking on iOS/macOS. Sizes and weights stay at
+  /// Material 3 defaults; only [TextStyle.letterSpacing] is replaced.
+  ///
+  /// When [base] is null, an empty [TextTheme] is used; `ThemeData` merges
+  /// the resulting styles on top of the default Material 3 [TextTheme], so
+  /// every Material-size remains intact.
+  static TextTheme _appleTextTheme(TextTheme? base, {required bool isIOS}) {
+    // Values from Apple HIG:
+    //   iOS: https://developer.apple.com/design/human-interface-guidelines/typography
+    //   macOS: same page, macOS typography table.
+    final titleLarge = isIOS ? -0.41 : 0.34;
+    final titleMedium = isIOS ? -0.32 : 0.38;
+    final titleSmall = isIOS ? -0.24 : 0.0;
+    final bodyLarge = isIOS ? -0.41 : 0.08;
+    final bodyMedium = isIOS ? -0.08 : 0.0;
+    final bodySmall = isIOS ? 0.0 : 0.06;
+    final labelLarge = isIOS ? -0.41 : -0.08;
+    final labelMedium = isIOS ? 0.06 : 0.12;
+    final labelSmall = isIOS ? 0.06 : 0.4;
+    final b = base ?? const TextTheme();
+    return b.copyWith(
+      titleLarge: (b.titleLarge ?? const TextStyle()).copyWith(
+        letterSpacing: titleLarge,
+      ),
+      titleMedium: (b.titleMedium ?? const TextStyle()).copyWith(
+        letterSpacing: titleMedium,
+      ),
+      titleSmall: (b.titleSmall ?? const TextStyle()).copyWith(
+        letterSpacing: titleSmall,
+      ),
+      bodyLarge: (b.bodyLarge ?? const TextStyle()).copyWith(
+        letterSpacing: bodyLarge,
+      ),
+      bodyMedium: (b.bodyMedium ?? const TextStyle()).copyWith(
+        letterSpacing: bodyMedium,
+      ),
+      bodySmall: (b.bodySmall ?? const TextStyle()).copyWith(
+        fontSize: 13,
+        letterSpacing: bodySmall,
+      ),
+      labelLarge: (b.labelLarge ?? const TextStyle()).copyWith(
+        letterSpacing: labelLarge,
+      ),
+      labelMedium: (b.labelMedium ?? const TextStyle()).copyWith(
+        letterSpacing: labelMedium,
+      ),
+      labelSmall: (b.labelSmall ?? const TextStyle()).copyWith(
+        fontSize: 12,
+        letterSpacing: labelSmall,
       ),
     );
   }

--- a/lib/pages/chat/chat_app_bar_title.dart
+++ b/lib/pages/chat/chat_app_bar_title.dart
@@ -76,7 +76,7 @@ class ChatAppBarTitle extends StatelessWidget {
                               builder: (context, presence) {
                                 final lastActiveTimestamp =
                                     presence?.lastActiveTimestamp;
-                                final style = TextStyle(fontSize: 11);
+                                final style = TextStyle(fontSize: 12);
                                 if (presence?.currentlyActive == true) {
                                   return Text(
                                     L10n.of(context).currentlyActive,
@@ -109,7 +109,7 @@ class ChatAppBarTitle extends StatelessWidget {
                                 Expanded(
                                   child: Text(
                                     status.calcLocalizedString(context),
-                                    style: TextStyle(fontSize: 12),
+                                    style: TextStyle(fontSize: 13),
                                   ),
                                 ),
                               ],

--- a/lib/pages/chat/events/audio_player.dart
+++ b/lib/pages/chat/events/audio_player.dart
@@ -493,11 +493,13 @@ class AudioPlayerState extends State<AudioPlayerWidget> {
                         style: TextStyle(
                           color: widget.color,
                           fontSize: widget.fontSize,
+                          height: AppConfig.messageLineHeight,
                         ),
                         options: const LinkifyOptions(humanize: false),
                         linkStyle: TextStyle(
                           color: widget.linkColor,
                           fontSize: widget.fontSize,
+                          height: AppConfig.messageLineHeight,
                           decoration: TextDecoration.underline,
                           decorationColor: widget.linkColor,
                         ),

--- a/lib/pages/chat/events/html_message.dart
+++ b/lib/pages/chat/events/html_message.dart
@@ -1,4 +1,5 @@
 import 'package:collection/collection.dart';
+import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/config/setting_keys.dart';
 import 'package:fluffychat/utils/code_highlight_theme.dart';
 import 'package:fluffychat/utils/event_checkbox_extension.dart';
@@ -309,7 +310,11 @@ class HtmlMessage extends StatelessWidget {
                     ),
                   ..._renderWithLineBreaks(node.nodes, context, depth: depth),
                 ],
-                style: TextStyle(fontSize: fontSize, color: textColor),
+                style: TextStyle(
+                  fontSize: fontSize,
+                  height: AppConfig.messageLineHeight,
+                  color: textColor,
+                ),
               ),
             ),
           ),
@@ -332,6 +337,7 @@ class HtmlMessage extends StatelessWidget {
               style: TextStyle(
                 fontStyle: FontStyle.italic,
                 fontSize: fontSize,
+                height: AppConfig.messageLineHeight,
                 color: textColor,
               ),
             ),
@@ -437,7 +443,11 @@ class HtmlMessage extends StatelessWidget {
                       ),
                   ],
                 ),
-                style: TextStyle(fontSize: fontSize, color: textColor),
+                style: TextStyle(
+                  fontSize: fontSize,
+                  height: AppConfig.messageLineHeight,
+                  color: textColor,
+                ),
               ),
             ),
           ),
@@ -464,6 +474,7 @@ class HtmlMessage extends StatelessWidget {
                 ),
                 style: TextStyle(
                   fontSize: fontSize,
+                  height: AppConfig.messageLineHeight,
                   color: textColor,
                   backgroundColor: obscure ? textColor : null,
                 ),
@@ -475,7 +486,11 @@ class HtmlMessage extends StatelessWidget {
       default:
         return TextSpan(
           style: switch (node.localName) {
-            'body' => TextStyle(fontSize: fontSize, color: textColor),
+            'body' => TextStyle(
+              fontSize: fontSize,
+              height: AppConfig.messageLineHeight,
+              color: textColor,
+            ),
             'a' => linkStyle,
             'strong' => const TextStyle(fontWeight: FontWeight.bold),
             'em' || 'i' => const TextStyle(fontStyle: FontStyle.italic),
@@ -516,7 +531,11 @@ class HtmlMessage extends StatelessWidget {
         : configuredMaxLines;
     return Text.rich(
       _renderHtml(element, context),
-      style: TextStyle(fontSize: fontSize, color: textColor),
+      style: TextStyle(
+        fontSize: fontSize,
+        height: AppConfig.messageLineHeight,
+        color: textColor,
+      ),
       maxLines: maxLines,
       overflow: maxLines == null ? TextOverflow.visible : TextOverflow.fade,
       selectionColor: textColor.withAlpha(128),

--- a/lib/pages/chat/events/image_bubble.dart
+++ b/lib/pages/chat/events/image_bubble.dart
@@ -1,5 +1,4 @@
 import 'package:fluffychat/config/app_config.dart';
-import 'package:fluffychat/config/setting_keys.dart';
 import 'package:fluffychat/utils/file_description.dart';
 import 'package:fluffychat/utils/url_launcher.dart';
 import 'package:fluffychat/widgets/mxc_image.dart';
@@ -118,16 +117,14 @@ class ImageBubble extends StatelessWidget {
                 textScaleFactor: MediaQuery.textScalerOf(context).scale(1),
                 style: TextStyle(
                   color: textColor,
-                  fontSize:
-                      AppSettings.fontSizeFactor.value *
-                      AppConfig.messageFontSize,
+                  fontSize: AppConfig.messageFontSize,
+                  height: AppConfig.messageLineHeight,
                 ),
                 options: const LinkifyOptions(humanize: false),
                 linkStyle: TextStyle(
                   color: linkColor,
-                  fontSize:
-                      AppSettings.fontSizeFactor.value *
-                      AppConfig.messageFontSize,
+                  fontSize: AppConfig.messageFontSize,
+                  height: AppConfig.messageLineHeight,
                   decoration: TextDecoration.underline,
                   decorationColor: linkColor,
                 ),

--- a/lib/pages/chat/events/message.dart
+++ b/lib/pages/chat/events/message.dart
@@ -253,7 +253,7 @@ class Message extends StatelessWidget {
                             child: Text(
                               event.originServerTs.localizedTime(context),
                               style: TextStyle(
-                                fontSize: 12 * AppSettings.fontSizeFactor.value,
+                                fontSize: 13,
                                 fontWeight: FontWeight.bold,
                                 color: theme.colorScheme.secondary,
                               ),
@@ -416,7 +416,7 @@ class Message extends StatelessWidget {
                                                   return Text(
                                                     displayname,
                                                     style: TextStyle(
-                                                      fontSize: 11,
+                                                      fontSize: 12,
                                                       fontWeight:
                                                           FontWeight.bold,
                                                       color:
@@ -606,7 +606,7 @@ class Message extends StatelessWidget {
                                                         style: TextStyle(
                                                           color: textColor
                                                               .withAlpha(164),
-                                                          fontSize: 11,
+                                                          fontSize: 12,
                                                         ),
                                                       ),
                                                     ],
@@ -887,9 +887,7 @@ class Message extends StatelessWidget {
                         ),
                         child: Text(
                           L10n.of(context).readUpToHere,
-                          style: TextStyle(
-                            fontSize: 12 * AppSettings.fontSizeFactor.value,
-                          ),
+                          style: const TextStyle(fontSize: 13),
                         ),
                       ),
                       Expanded(

--- a/lib/pages/chat/events/message_content.dart
+++ b/lib/pages/chat/events/message_content.dart
@@ -105,8 +105,7 @@ class MessageContent extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final fontSize =
-        AppConfig.messageFontSize * AppSettings.fontSizeFactor.value;
+    final fontSize = AppConfig.messageFontSize;
     final buttonTextColor = textColor;
     switch (event.type) {
       case EventTypes.Message:
@@ -269,16 +268,12 @@ class MessageContent extends StatelessWidget {
                 html: html,
                 textColor: textColor,
                 room: event.room,
-                fontSize:
-                    AppSettings.fontSizeFactor.value *
-                    AppConfig.messageFontSize *
-                    (bigEmotes ? 5 : 1),
+                fontSize: AppConfig.messageFontSize * (bigEmotes ? 5 : 1),
                 limitHeight: !selected,
                 linkStyle: TextStyle(
                   color: linkColor,
-                  fontSize:
-                      AppSettings.fontSizeFactor.value *
-                      AppConfig.messageFontSize,
+                  fontSize: AppConfig.messageFontSize,
+                  height: AppConfig.messageLineHeight,
                   decoration: TextDecoration.underline,
                   decorationColor: linkColor,
                 ),
@@ -404,7 +399,11 @@ class _ButtonContent extends StatelessWidget {
         onTap: onPressed,
         child: Text(
           '$icon  $label',
-          style: TextStyle(color: textColor, fontSize: fontSize),
+          style: TextStyle(
+            color: textColor,
+            fontSize: fontSize,
+            height: AppConfig.messageLineHeight,
+          ),
         ),
       ),
     );

--- a/lib/pages/chat/events/message_download_content.dart
+++ b/lib/pages/chat/events/message_download_content.dart
@@ -1,5 +1,4 @@
 import 'package:fluffychat/config/app_config.dart';
-import 'package:fluffychat/config/setting_keys.dart';
 import 'package:fluffychat/utils/file_description.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/event_extension.dart';
 import 'package:fluffychat/utils/url_launcher.dart';
@@ -91,16 +90,14 @@ class MessageDownloadContent extends StatelessWidget {
               textScaleFactor: MediaQuery.textScalerOf(context).scale(1),
               style: TextStyle(
                 color: textColor,
-                fontSize:
-                    AppSettings.fontSizeFactor.value *
-                    AppConfig.messageFontSize,
+                fontSize: AppConfig.messageFontSize,
+                height: AppConfig.messageLineHeight,
               ),
               options: const LinkifyOptions(humanize: false),
               linkStyle: TextStyle(
                 color: linkColor,
-                fontSize:
-                    AppSettings.fontSizeFactor.value *
-                    AppConfig.messageFontSize,
+                fontSize: AppConfig.messageFontSize,
+                height: AppConfig.messageLineHeight,
                 decoration: TextDecoration.underline,
                 decorationColor: linkColor,
               ),

--- a/lib/pages/chat/events/poll.dart
+++ b/lib/pages/chat/events/poll.dart
@@ -73,16 +73,14 @@ class PollWidget extends StatelessWidget {
               textScaleFactor: MediaQuery.textScalerOf(context).scale(1),
               style: TextStyle(
                 color: textColor,
-                fontSize:
-                    AppSettings.fontSizeFactor.value *
-                    AppConfig.messageFontSize,
+                fontSize: AppConfig.messageFontSize,
+                height: AppConfig.messageLineHeight,
               ),
               options: const LinkifyOptions(humanize: false),
               linkStyle: TextStyle(
                 color: linkColor,
-                fontSize:
-                    AppSettings.fontSizeFactor.value *
-                    AppConfig.messageFontSize,
+                fontSize: AppConfig.messageFontSize,
+                height: AppConfig.messageLineHeight,
                 decoration: TextDecoration.underline,
                 decorationColor: linkColor,
               ),
@@ -120,9 +118,8 @@ class PollWidget extends StatelessWidget {
                   overflow: TextOverflow.ellipsis,
                   style: TextStyle(
                     color: textColor,
-                    fontSize:
-                        AppConfig.messageFontSize *
-                        AppSettings.fontSizeFactor.value,
+                    fontSize: AppConfig.messageFontSize,
+                    height: AppConfig.messageLineHeight,
                   ),
                 ),
                 subtitle: answersVisible
@@ -142,8 +139,7 @@ class PollWidget extends StatelessWidget {
                                   overflow: TextOverflow.ellipsis,
                                   style: TextStyle(
                                     color: linkColor,
-                                    fontSize:
-                                        12 * AppSettings.fontSizeFactor.value,
+                                    fontSize: 12,
                                   ),
                                 ),
                                 const SizedBox(width: 2),
@@ -204,7 +200,7 @@ class PollWidget extends StatelessWidget {
                 L10n.of(context).answersWillBeVisibleWhenPollHasEnded,
                 style: TextStyle(
                   color: linkColor,
-                  fontSize: 12 * AppSettings.fontSizeFactor.value,
+                  fontSize: 12,
                   fontStyle: FontStyle.italic,
                 ),
               ),
@@ -216,7 +212,7 @@ class PollWidget extends StatelessWidget {
                 L10n.of(context).pollHasBeenEnded,
                 style: TextStyle(
                   color: linkColor,
-                  fontSize: 12 * AppSettings.fontSizeFactor.value,
+                  fontSize: 12,
                   fontStyle: FontStyle.italic,
                 ),
               ),

--- a/lib/pages/chat/events/reply_content.dart
+++ b/lib/pages/chat/events/reply_content.dart
@@ -1,4 +1,3 @@
-import 'package:fluffychat/config/setting_keys.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/matrix_locals.dart';
 import 'package:flutter/material.dart';
@@ -31,8 +30,7 @@ class ReplyContent extends StatelessWidget {
     final displayEvent = timeline != null
         ? replyEvent.getDisplayEvent(timeline)
         : replyEvent;
-    final fontSize =
-        AppConfig.messageFontSize * AppSettings.fontSizeFactor.value;
+    final fontSize = AppConfig.messageFontSize;
     final color = theme.brightness == Brightness.dark
         ? theme.colorScheme.onTertiaryContainer
         : ownMessage
@@ -71,6 +69,7 @@ class ReplyContent extends StatelessWidget {
                         fontWeight: FontWeight.bold,
                         color: color,
                         fontSize: fontSize,
+                        height: AppConfig.messageLineHeight,
                       ),
                     );
                   },
@@ -91,6 +90,7 @@ class ReplyContent extends StatelessWidget {
                         ? theme.colorScheme.onTertiary
                         : theme.colorScheme.onSurface,
                     fontSize: fontSize,
+                    height: AppConfig.messageLineHeight,
                   ),
                 ),
               ],

--- a/lib/pages/chat/events/state_message.dart
+++ b/lib/pages/chat/events/state_message.dart
@@ -1,4 +1,3 @@
-import 'package:fluffychat/config/setting_keys.dart';
 import 'package:fluffychat/config/themes.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/matrix_locals.dart';
@@ -66,7 +65,7 @@ class StateMessage extends StatelessWidget {
                         ),
                         textAlign: TextAlign.center,
                         style: TextStyle(
-                          fontSize: 11 * AppSettings.fontSizeFactor.value,
+                          fontSize: 12,
                           decoration: event.redacted
                               ? TextDecoration.lineThrough
                               : null,

--- a/lib/pages/chat/events/video_player.dart
+++ b/lib/pages/chat/events/video_player.dart
@@ -1,7 +1,6 @@
 import 'dart:math';
 
 import 'package:fluffychat/config/app_config.dart';
-import 'package:fluffychat/config/setting_keys.dart';
 import 'package:fluffychat/utils/file_description.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/event_extension.dart';
 import 'package:fluffychat/utils/platform_infos.dart';
@@ -136,16 +135,14 @@ class EventVideoPlayer extends StatelessWidget {
                 textScaleFactor: MediaQuery.textScalerOf(context).scale(1),
                 style: TextStyle(
                   color: textColor,
-                  fontSize:
-                      AppSettings.fontSizeFactor.value *
-                      AppConfig.messageFontSize,
+                  fontSize: AppConfig.messageFontSize,
+                  height: AppConfig.messageLineHeight,
                 ),
                 options: const LinkifyOptions(humanize: false),
                 linkStyle: TextStyle(
                   color: linkColor,
-                  fontSize:
-                      AppSettings.fontSizeFactor.value *
-                      AppConfig.messageFontSize,
+                  fontSize: AppConfig.messageFontSize,
+                  height: AppConfig.messageLineHeight,
                   decoration: TextDecoration.underline,
                   decorationColor: linkColor,
                 ),

--- a/lib/pages/chat/input_bar.dart
+++ b/lib/pages/chat/input_bar.dart
@@ -392,6 +392,10 @@ class InputBar extends StatelessWidget {
         controller: controller,
         focusNode: focusNode,
         readOnly: readOnly,
+        style: TextStyle(
+          fontSize: AppConfig.messageFontSize,
+          height: AppConfig.messageLineHeight,
+        ),
         onEditingComplete: () {
           // To not lose focus on iOS:
           // https://github.com/krille-chan/fluffychat/issues/2784

--- a/lib/pages/chat_list/chat_list_item.dart
+++ b/lib/pages/chat_list/chat_list_item.dart
@@ -220,7 +220,7 @@ class ChatListItem extends StatelessWidget {
                           context,
                         ),
                         style: TextStyle(
-                          fontSize: 11,
+                          fontSize: 12,
                           fontWeight: room.hasNewMessages
                               ? FontWeight.bold
                               : null,
@@ -285,7 +285,7 @@ class ChatListItem extends StatelessWidget {
                                 const SizedBox(width: 4),
                                 Text(
                                   L10n.of(context).thread,
-                                  style: TextStyle(fontSize: 11),
+                                  style: TextStyle(fontSize: 12),
                                 ),
                               ],
                             ),

--- a/lib/pages/settings_style/settings_style.dart
+++ b/lib/pages/settings_style/settings_style.dart
@@ -1,4 +1,5 @@
 import 'package:file_picker/file_picker.dart';
+import 'package:fluffychat/config/app_font_size.dart';
 import 'package:fluffychat/config/setting_keys.dart';
 import 'package:fluffychat/utils/account_config.dart';
 import 'package:fluffychat/utils/file_selector.dart';
@@ -128,6 +129,7 @@ class SettingsStyleController extends State<SettingsStyle> {
 
   Future<void> changeFontSizeFactor(double d) async {
     await AppSettings.fontSizeFactor.setItem(d);
+    fontSizeFactorNotifier.value = d;
     setState(() {});
   }
 

--- a/lib/pages/settings_style/settings_style_view.dart
+++ b/lib/pages/settings_style/settings_style_view.dart
@@ -227,9 +227,8 @@ class SettingsStyleView extends StatelessWidget {
                                       'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor',
                                       style: TextStyle(
                                         color: theme.onBubbleColor,
-                                        fontSize:
-                                            AppConfig.messageFontSize *
-                                            AppSettings.fontSizeFactor.value,
+                                        fontSize: AppConfig.messageFontSize,
+                                        height: AppConfig.messageLineHeight,
                                       ),
                                     ),
                                   ),
@@ -261,9 +260,8 @@ class SettingsStyleView extends StatelessWidget {
                                         'Lorem ipsum dolor sit amet',
                                         style: TextStyle(
                                           color: theme.colorScheme.onSurface,
-                                          fontSize:
-                                              AppConfig.messageFontSize *
-                                              AppSettings.fontSizeFactor.value,
+                                          fontSize: AppConfig.messageFontSize,
+                                          height: AppConfig.messageLineHeight,
                                         ),
                                       ),
                                     ),

--- a/lib/widgets/fluffy_chat_app.dart
+++ b/lib/widgets/fluffy_chat_app.dart
@@ -1,4 +1,5 @@
 import 'package:fluffychat/config/app_config.dart';
+import 'package:fluffychat/config/app_font_size.dart';
 import 'package:fluffychat/config/routes.dart';
 import 'package:fluffychat/config/setting_keys.dart';
 import 'package:fluffychat/config/themes.dart';
@@ -65,16 +66,29 @@ class FluffyChatApp extends StatelessWidget {
         localizationsDelegates: L10n.localizationsDelegates,
         supportedLocales: L10n.supportedLocales,
         routerConfig: router,
-        builder: (context, child) => AppLockWidget(
-          pincode: pincode,
-          clients: clients,
-          // Need a navigator above the Matrix widget for
-          // displaying dialogs
-          child: Matrix(
-            clients: clients,
-            store: store,
-            child: testWidget ?? child,
-          ),
+        builder: (context, child) => ValueListenableBuilder<double>(
+          valueListenable: fontSizeFactorNotifier,
+          builder: (context, factor, _) {
+            final system = MediaQuery.textScalerOf(context);
+            return MediaQuery(
+              data: MediaQuery.of(context).copyWith(
+                textScaler: factor == 1.0
+                    ? system
+                    : ScaledTextScaler(system, factor),
+              ),
+              child: AppLockWidget(
+                pincode: pincode,
+                clients: clients,
+                // Need a navigator above the Matrix widget for
+                // displaying dialogs
+                child: Matrix(
+                  clients: clients,
+                  store: store,
+                  child: testWidget ?? child,
+                ),
+              ),
+            );
+          },
         ),
       ),
     );


### PR DESCRIPTION
Hi! I've been using FluffyChat on macOS for a while and the thing that kept bothering me is how the text never quite fits in with the rest of the desktop. Next to Mail, Messages or Telegram Desktop the fonts are visibly smaller and a little "off" — wrong family, too much letter-spacing, too much vertical space between lines. Once you notice it you can't un-notice it, and there was no slider or setting that fixed it cleanly.

This PR is a coordinated attempt to close that gap on macOS while not touching how the app looks on the other platforms.

## What changes

**The font-size slider now affects the whole UI, not just bubbles.** Previously `AppSettings.fontSizeFactor` was multiplied into ~28 call sites inside message widgets, so moving the slider in Settings → Style would only resize message text; chat list, app bar, dialogs and the compose input stayed put. I wrapped the router in a MediaQuery that combines the OS `textScaler` with the user factor and deleted those 28 manual multiplications. Now the slider affects everything, and iOS Dynamic Type / Android font scale still work — they compose multiplicatively with the user's preference.

**SF Pro on Apple platforms.** The theme now sets `fontFamily: 'CupertinoSystemText'` on iOS and macOS, which the Flutter engine resolves to `.AppleSystemUIFont` with the native Display↔Text split at 20pt. The TextTheme also gets Apple HIG letter-spacing for body / label / title roles (iOS body uses `−0.41`, macOS uses near-zero or slightly positive), so SF Pro is rendered the way Apple intended instead of being run through Material's `+0.25` / `+0.5` tracking that was optimised for Roboto. The composer TextField picks up the same size so typing matches the bubbles.

**Message body is 14pt on macOS (still 16pt elsewhere).** `AppConfig.messageFontSize` is now platform-aware. 14pt is what Telegram Desktop, Mail and the other native macOS chat apps use; 16pt was Material's Android-centric default and felt out of place on the desktop.

**Tighter line-height on macOS.** A new `AppConfig.messageLineHeight = 1.25` is threaded through every TextStyle that renders body-sized text — plain text, Linkify styles, reply quotes, image / video / file captions, poll question + answers, HtmlMessage paragraphs and blockquotes, audio player caption and the Settings → Style preview. Off-macOS this value is \`null\`, so every TextStyle falls back to the font's intrinsic leading and nothing visually changes. HtmlMessage headings (h1–h6) keep their own higher \`height\` values because at larger sizes Material-style breathing room still reads better than a compressed 1.25.

**Chat list / app bar hierarchy.** As a side-effect of the slider fix, the gap between sender title and secondary text (preview, timestamp, presence) was uncomfortably wide — roughly −4 to −5pt instead of Telegram's −1 to −3. I lifted six hardcoded \`fontSize: 11\` / \`fontSize: 12\` values by one point across \`chat_list_item\`, \`chat_app_bar_title\`, \`message.dart\` (sender name / bubble time / read marker) and \`state_message\`. Small change; big readability win.

## Why one PR

The pieces are interdependent. The global MediaQuery wrapper would double-scale every bubble without the manual-multiplier cleanup. The 14pt macOS body only makes sense once \`platformFontFactor\` isn't multiplying everything else on top. The line-height constant wouldn't land without the AppConfig refactor. So it's 19 files in one signed commit (+218 / −80, one new file — \`lib/config/app_font_size.dart\` — for the \`ValueNotifier<double>\` and the \`ScaledTextScaler\` that the MediaQuery wrapper uses). Happy to split it if you'd prefer, but each concern depends on the previous one landing.

## Verification

- \`dart format lib\` — clean.
- \`flutter analyze\` — no issues.
- \`flutter test\` — 4/4 passing.
- Manually tested on macOS with the slider at 0.5, 1.0, 1.5 and 2.5; body, chat list, settings, dialogs and compose all respond. Default slider (1.0) on a Retina display now looks like what you'd expect from a native app sitting next to Mail or Telegram Desktop.
- On Android / iOS / Linux / Windows / Web the visible diff is a \`+1pt\` bump on six hardcoded secondary-text sites and nothing else — \`messageLineHeight\` is \`null\` off-macOS, \`messageFontSize\` stays at 16pt, and the Apple \`fontFamily\` / letter-spacing branches only fire on iOS and macOS.

## Related

Refs #1329. This doesn't touch the iOS Dynamic Type letter-spacing table from that proposal directly, but it does ship the \`fontFamily\` + letter-spacing side and adds a macOS-specific answer alongside it.