### PR TITLE
feat: enable voice message recording on Linux desktop

### DIFF
--- a/lib/utils/platform_infos.dart
+++ b/lib/utils/platform_infos.dart
@@ -36,7 +36,7 @@ abstract class PlatformInfos {
       PlatformInfos.isWeb || PlatformInfos.isMobile;
 
   /// Web could also record in theory but currently creates broken opus
-  static bool get platformCanRecord => (isMobile || isMacOS);
+  static bool get platformCanRecord => (isMobile || isMacOS || isLinux);
 
   static String get clientName =>
       '${AppSettings.applicationName.value} ${isWeb ? 'web' : Platform.operatingSystem}${kReleaseMode ? '' : 'Debug'}';


### PR DESCRIPTION
## Summary
Voice message recording is currently disabled on Linux desktop via a hardcoded platform check in `lib/utils/platform_infos.dart`.

This PR enables it by adding `isLinux` to `platformCanRecord`.

## Why
- The underlying `record` package (v6.2.0) already fully supports Linux through GStreamer.
- The UI widgets (recording button, waveform, opus encoding) are platform-agnostic and work out of the box.
- I have built and tested this locally on Arch Linux (Hyprland/PipeWire) and voice recording, playback, and sending all work correctly.

## What changed
- `platformCanRecord` now returns `true` for Linux in addition to mobile and macOS.

## Testing environment
- **OS:** Arch Linux (latest)
- **Desktop / WM:** Hyprland (Wayland)
- **Audio:** PipeWire + WirePlumber
- **FluffyChat version:** 2.5.1+3551 (built from source with Flutter 3.41.7)
- No errors or regressions were detected during testing.

Fixes #2901