### PR TITLE
feat: hide rooms in spaces

### DIFF
--- a/lib/config/setting_keys.dart
+++ b/lib/config/setting_keys.dart
@@ -71,7 +71,8 @@ enum AppSettings<T> {
   tos<String>('chat.fluffy.tos_url', 'https://fluffychat.im/en/tos'),
   sendTimelineEventTimeout<int>('chat.fluffy.send_timeline_event_timeout', 15),
   webNotificationSound<bool>('chat.fluffy.web_notification_sound', true),
-  chatFilter<String>('chat.fluffy.chat_filter', 'allChats');
+  chatFilter<String>('chat.fluffy.chat_filter', 'allChats'),
+  hideRoomsInSpaces<bool>('chat.fluffy.hideRoomsInSpaces', false);
 
   final String key;
   final T defaultValue;

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -2799,5 +2799,6 @@
     "addTag": "Add tag",
     "removeTag": "Remove tag",
     "tagName": "Tag name",
-    "createNewTag": "Create new tag"
+    "createNewTag": "Create new tag",
+    "hideRoomsInSpaces": "Hide rooms that are in a space"
 }

--- a/lib/pages/chat_list/chat_list_body.dart
+++ b/lib/pages/chat_list/chat_list_body.dart
@@ -63,7 +63,13 @@ class ChatListViewBody extends StatelessWidget {
           .where((s) => s.hasRoomUpdate)
           .rateLimit(const Duration(seconds: 1)),
       builder: (context, _) {
-        final rooms = controller.filteredRooms;
+        final rooms = controller.filteredRooms
+            .where(
+              (room) =>
+                  !AppSettings.hideRoomsInSpaces.value ||
+                  spaceDelegateCandidates[room.id] == null,
+            )
+            .toList();
 
         return SafeArea(
           child: CustomScrollView(

--- a/lib/pages/settings_chat/settings_chat_view.dart
+++ b/lib/pages/settings_chat/settings_chat_view.dart
@@ -40,6 +40,10 @@ class SettingsChatView extends StatelessWidget {
                 setting: AppSettings.hideRedactedEvents,
               ),
               SettingsSwitchListTile.adaptive(
+                title: L10n.of(context).hideRoomsInSpaces,
+                setting: AppSettings.hideRoomsInSpaces,
+              ),
+              SettingsSwitchListTile.adaptive(
                 title: L10n.of(context).hideInvalidOrUnknownMessageFormats,
                 setting: AppSettings.hideUnknownEvents,
               ),


### PR DESCRIPTION
This adds a setting to prevent chats that are in a space from being shown in the chat list view. For more motivation see https://github.com/krille-chan/fluffychat/issues/2788 or https://github.com/krille-chan/fluffychat/issues/1273. 

I am not very comfortable with the code style and standards of this project so I fully expect to find many issues here and am prepared to fix those, but I would need some pointers on things to improve.

- [x] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [x] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS