### PR TITLE
fix: push helper when devices is empty list

### DIFF
--- a/lib/utils/push_helper.dart
+++ b/lib/utils/push_helper.dart
@@ -85,7 +85,7 @@ Future<void> _tryPushHelper(
     return;
   }
 
-  final clientName = notification.devices?.first.data?.tryGet<String>(
+  final clientName = notification.devices?.firstOrNull?.data?.tryGet<String>(
     'client_name',
   );
   final store = await AppSettings.init();


### PR DESCRIPTION
I'm getting this in the main branch, last checked against 1e0c5a5e7388b219aae8e7723f586d3dea1326d1:

```
# [VERBOSE] Push helper has been started (background=false). - {counts: {unread: 1}, devices: [], event_id: REDACTED, prio: high, room_id: REDACTED}
# [ERROR] Push Helper has crashed! Writing into temporary file - Bad state: No element
#0      List.first (dart:core-patch/growable_array.dart:352)
#1      _tryPushHelper (package:fluffychat/utils/push_helper.dart:88)
#2      pushHelper (package:fluffychat/utils/push_helper.dart:31)
#3      BackgroundPush._onUpMessage (package:fluffychat/utils/background_push.dart:451)
#4      UnifiedPush.initialize.<anonymous closure> (package:unifiedpush/unifiedpush.dart:85)
#5      UnifiedPushAndroid.onMethodCall (package:unifiedpush_android/unifiedpush_android.dart:145)
#6      MethodChannel._handleAsMethodCall (package:flutter/src/services/platform_channel.dart:607)
#7      MethodChannel.setMethodCallHandler.<anonymous closure> (package:flutter/src/services/platform_channel.dart:597)
#8      _DefaultBinaryMessenger.setMessageHandler.<anonymous closure> (package:flutter/src/services/binding.dart:663)
#9      _invoke2 (dart:ui/hooks.dart:388)
#10     _ChannelCallbackRecord.invoke (dart:ui/channel_buffers.dart:45)
#11     _Channel.push (dart:ui/channel_buffers.dart:136)
#12     ChannelBuffers.push (dart:ui/channel_buffers.dart:344)
#13     PlatformDispatcher._dispatchPlatformMessage (dart:ui/platform_dispatcher.dart:819)
#14     _dispatchPlatformMessage (dart:ui/hooks.dart:302)
```

- [x] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [x] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS