### PR TITLE
feat: collapsible long messages with show more/less

### DIFF
--- a/lib/config/setting_keys.dart
+++ b/lib/config/setting_keys.dart
@@ -16,7 +16,7 @@ enum AppSettings<T> {
   textMessageMaxLength<int>('textMessageMaxLength', 16384),
 
   /// Max lines for unselected HTML/text bubbles; 0 = unlimited (no fade).
-  messagePreviewMaxLines<int>('chat.fluffy.message_preview_max_lines', 128),
+  messagePreviewMaxLines<int>('chat.fluffy.message_preview_max_lines', 20),
   audioRecordingNumChannels<int>('audioRecordingNumChannels', 1),
   audioRecordingAutoGain<bool>('audioRecordingAutoGain', true),
   audioRecordingEchoCancel<bool>('audioRecordingEchoCancel', false),

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -2602,6 +2602,8 @@
     "displayNavigationRail": "Show navigation rail on mobile",
     "customReaction": "Custom reaction",
     "moreEvents": "More events",
+    "showMore": "Show more",
+    "showLess": "Show less",
     "declineInvitation": "Decline invitation",
     "noMessagesYet": "No messages yet",
     "longPressToRecordVoiceMessage": "Long press to record voice message.",

--- a/lib/pages/chat/events/html_message.dart
+++ b/lib/pages/chat/events/html_message.dart
@@ -5,6 +5,7 @@
 
 import 'package:collection/collection.dart';
 import 'package:fluffychat/config/setting_keys.dart';
+import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/utils/code_highlight_theme.dart';
 import 'package:fluffychat/utils/event_checkbox_extension.dart';
 import 'package:fluffychat/widgets/avatar.dart';
@@ -468,6 +469,8 @@ class HtmlMessage extends StatelessWidget {
       case 'th':
       case 'td':
       case 'caption':
+        // These are handled by the 'table' case above; if encountered
+        // outside a table, render children inline as fallback.
         return TextSpan(
           children: _renderWithLineBreaks(node.nodes, context, depth: depth),
         );
@@ -587,12 +590,98 @@ class HtmlMessage extends StatelessWidget {
     final maxLines = !limitHeight || configuredMaxLines <= 0
         ? null
         : configuredMaxLines;
-    return Text.rich(
-      _renderHtml(element, context),
-      style: TextStyle(fontSize: fontSize, color: textColor),
+    final span = _renderHtml(element, context);
+    final style = TextStyle(fontSize: fontSize, color: textColor);
+
+    if (maxLines == null) {
+      return Text.rich(
+        span,
+        style: style,
+        selectionColor: textColor.withAlpha(128),
+      );
+    }
+
+    // Heuristic: if plain text has enough newlines or length, it will overflow.
+    final plainText = element.text;
+    final lineCount = '\n'.allMatches(plainText).length + 1;
+    final likelyOverflows =
+        lineCount > maxLines || plainText.length > maxLines * 50;
+
+    if (!likelyOverflows) {
+      return Text.rich(
+        span,
+        style: style,
+        selectionColor: textColor.withAlpha(128),
+      );
+    }
+
+    return _CollapsibleText(
+      span: span,
+      style: style,
       maxLines: maxLines,
-      overflow: maxLines == null ? TextOverflow.visible : TextOverflow.fade,
-      selectionColor: textColor.withAlpha(128),
+      textColor: textColor,
+      linkColor: linkStyle.color ?? textColor,
+      fontSize: fontSize,
+    );
+  }
+}
+
+class _CollapsibleText extends StatefulWidget {
+  final InlineSpan span;
+  final TextStyle style;
+  final int maxLines;
+  final Color textColor;
+  final Color linkColor;
+  final double fontSize;
+
+  const _CollapsibleText({
+    required this.span,
+    required this.style,
+    required this.maxLines,
+    required this.textColor,
+    required this.linkColor,
+    required this.fontSize,
+  });
+
+  @override
+  State<_CollapsibleText> createState() => _CollapsibleTextState();
+}
+
+class _CollapsibleTextState extends State<_CollapsibleText> {
+  bool _expanded = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = L10n.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        AnimatedSize(
+          duration: const Duration(milliseconds: 200),
+          alignment: Alignment.topLeft,
+          child: Text.rich(
+            widget.span,
+            style: widget.style,
+            maxLines: _expanded ? null : widget.maxLines,
+            overflow: _expanded ? TextOverflow.visible : TextOverflow.ellipsis,
+            selectionColor: widget.textColor.withAlpha(128),
+          ),
+        ),
+        GestureDetector(
+          onTap: () => setState(() => _expanded = !_expanded),
+          child: Padding(
+            padding: const EdgeInsets.only(top: 4),
+            child: Text(
+              _expanded ? '↑ ${l10n.showLess}' : '↓ ${l10n.showMore}',
+              style: TextStyle(
+                color: widget.linkColor,
+                fontSize: widget.fontSize * 0.85,
+              ),
+            ),
+          ),
+        ),
+      ],
     );
   }
 }


### PR DESCRIPTION
Long messages are clipped with `TextOverflow.fade` at 128 lines with no way to read the full content except press-hold selecting the bubble. This replaces the fade with an inline "Show more" / "Show less" toggle.

- Reduce default `messagePreviewMaxLines` from 128 to 20
- Use a DOM text heuristic (line count + character length) to detect messages that will overflow, since `TextPainter` cannot measure `WidgetSpan`s
- Add `_CollapsibleText` widget with `AnimatedSize` for smooth expand/collapse
- Add L10n keys `showMore` and `showLess`

Short messages render without any button. Long messages show truncated with ellipsis and a "↓ Show more" link. Tapping expands the full message with a smooth 200ms animation and the link changes to "↑ Show less" to collapse back.

Refs #2820

---

- [x] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md).

### Pull Request has been tested on:
- [x] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<img width="300" height="668" alt="share_6759720282158837964" src="https://github.com/user-attachments/assets/4b61b676-a4fd-4c41-8a33-d4d5f357b7fa" />

<img width="300" height="668" alt="Screenshot_20260524-160112" src="https://github.com/user-attachments/assets/f0fa1bf3-5726-4298-bca1-ebf413143084" />
