### PR TITLE
feat: Client-side push notification filtering for encrypted rooms

### DIFF
--- a/lib/utils/push_helper.dart
+++ b/lib/utils/push_helper.dart
@@ -160,6 +160,11 @@ Future<void> _tryPushHelper(
   }
   Logs().v('Push helper got notification event of type ${event.type}.');
 
+  if (!client.pushruleEvaluator.match(event).notify) {
+    Logs().i('Push helper: filtered by client-side push rules.');
+    return;
+  }
+
   if (event.type.startsWith('m.call')) {
     // make sure bg sync is on (needed to update hold, unhold events)
     // prevent over write from app life cycle change


### PR DESCRIPTION
MSC3952 (Intentional Mentions) was rewritten to no longer allow signalling mentions in the unencrypted wrapper of encrypted events, as it would leak metadata about room activity to the server.

Because of this, users who want to receive mention or @room notifications in encrypted rooms have to enable push notifications for all encrypted messages. FluffyChat did not filter these client-side since the device wakes up for every message regardless, meaning battery drains the same whether notifications are shown or not. However, this causes the device to be spammed with a notification for every single message.

Adds an opt-in setting under the encrypted room notification push rule that decrypts each incoming message on arrival and evaluates the full push rule set locally, replicating the same filters the user has configured for unencrypted rooms. This stops the spam without any additional battery impact.
1:1 encrypted rooms are unaffected as push rules already notify for all direct messages.

- [x] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [x] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS