### PR TITLE
feat: add inline PDF viewer for Matrix file attachments

### DIFF
--- a/lib/attachment/attachment_renderer.dart
+++ b/lib/attachment/attachment_renderer.dart
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: 2019-Present Christian Kußowski
+// SPDX-FileCopyrightText: 2019-Present Contributors to FluffyChat
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import 'package:flutter/material.dart';
+import 'package:matrix/matrix.dart';
+
+import 'attachment_style.dart';
+
+abstract class AttachmentRenderer {
+  const AttachmentRenderer();
+  Widget build(BuildContext context, Event event, AttachmentStyle style);
+}

--- a/lib/attachment/attachment_style.dart
+++ b/lib/attachment/attachment_style.dart
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2019-Present Christian Kußowski
+// SPDX-FileCopyrightText: 2019-Present Contributors to FluffyChat
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import 'package:flutter/material.dart';
+
+class AttachmentStyle {
+  final Color textColor;
+  final Color linkColor;
+  final BorderRadius borderRadius;
+
+  const AttachmentStyle({
+    required this.textColor,
+    required this.linkColor,
+    required this.borderRadius,
+  });
+}

--- a/lib/attachment/default_attachment_renderer.dart
+++ b/lib/attachment/default_attachment_renderer.dart
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2019-Present Christian Kußowski
+// SPDX-FileCopyrightText: 2019-Present Contributors to FluffyChat
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import 'package:fluffychat/pages/chat/events/message_download_content.dart';
+import 'package:fluffychat/pages/chat/events/pdf/pdf_bubble.dart';
+import 'package:fluffychat/utils/platform_infos.dart';
+import 'package:flutter/material.dart';
+import 'package:matrix/matrix.dart';
+
+import 'attachment_renderer.dart';
+import 'attachment_style.dart';
+
+class DefaultAttachmentRenderer extends AttachmentRenderer {
+  const DefaultAttachmentRenderer();
+
+  // pdfx native renderers: Android (PdfRenderer), iOS/macOS (PDFKit),
+  // Windows (pdfium). Linux has no bundled pdfium. Web requires a CDN
+  // pdf.js that is unreliable in air-gapped / encrypted-content flows.
+  static bool get _pdfxSupported =>
+      !PlatformInfos.isLinux && !PlatformInfos.isWeb;
+
+  @override
+  Widget build(BuildContext context, Event event, AttachmentStyle style) {
+    final mimetype = event.content
+        .tryGetMap<String, Object?>('info')
+        ?.tryGet<String>('mimetype');
+
+    if (mimetype == 'application/pdf' && _pdfxSupported) {
+      return PdfBubble(event: event, style: style);
+    }
+
+    return MessageDownloadContent(
+      event,
+      textColor: style.textColor,
+      linkColor: style.linkColor,
+    );
+  }
+}

--- a/lib/pages/chat/events/message_content.dart
+++ b/lib/pages/chat/events/message_content.dart
@@ -20,6 +20,8 @@ import 'package:go_router/go_router.dart';
 import 'package:matrix/encryption.dart';
 import 'package:matrix/matrix.dart';
 
+import '../../../attachment/attachment_style.dart';
+import '../../../attachment/default_attachment_renderer.dart';
 import '../../../config/app_config.dart';
 import '../../../utils/event_checkbox_extension.dart';
 import '../../../utils/platform_infos.dart';
@@ -191,10 +193,14 @@ class MessageContent extends StatelessWidget {
               timeline: timeline,
             );
           case MessageTypes.File:
-            return MessageDownloadContent(
+            return const DefaultAttachmentRenderer().build(
+              context,
               event,
-              textColor: textColor,
-              linkColor: linkColor,
+              AttachmentStyle(
+                textColor: textColor,
+                linkColor: linkColor,
+                borderRadius: borderRadius,
+              ),
             );
           case MessageTypes.BadEncrypted:
           case EventTypes.Encrypted:

--- a/lib/pages/chat/events/pdf/pdf_bubble.dart
+++ b/lib/pages/chat/events/pdf/pdf_bubble.dart
@@ -1,0 +1,360 @@
+// SPDX-FileCopyrightText: 2019-Present Christian Kußowski
+// SPDX-FileCopyrightText: 2019-Present Contributors to FluffyChat
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import 'dart:io';
+
+import 'package:fluffychat/attachment/attachment_style.dart';
+import 'package:fluffychat/config/app_config.dart';
+import 'package:fluffychat/pages/chat/events/pdf/pdf_cache.dart';
+import 'package:fluffychat/pages/chat/events/pdf/pdf_viewer_screen.dart';
+import 'package:fluffychat/utils/matrix_sdk_extensions/event_extension.dart';
+import 'package:fluffychat/widgets/future_loading_dialog.dart';
+import 'package:flutter/material.dart';
+import 'package:matrix/matrix.dart';
+import 'package:pdfx/pdfx.dart';
+
+class PdfBubble extends StatefulWidget {
+  final Event event;
+  final AttachmentStyle style;
+
+  const PdfBubble({required this.event, required this.style, super.key});
+
+  @override
+  State<PdfBubble> createState() => _PdfBubbleState();
+}
+
+enum _Status { idle, ready, error }
+
+class _PdfBubbleState extends State<PdfBubble>
+    with AutomaticKeepAliveClientMixin {
+  _Status _status = _Status.idle;
+  PdfController? _controller;
+  String? _cachedPath;
+  String? _thumbnailPath;
+  bool _isLoading = false;
+
+  // Keep the loaded PDF alive when it scrolls off-screen.
+  // AutomaticKeepAliveClientMixin + wantKeepAlive replaces any need for a
+  // static controller cache — the controller stays alive in memory for the
+  // lifetime of the ListView's scroll view.
+  @override
+  bool get wantKeepAlive => _status == _Status.ready;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadThumbnailIfCached();
+  }
+
+  @override
+  void didUpdateWidget(PdfBubble oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.event.eventId != widget.event.eventId) {
+      _controller?.dispose();
+      _controller = null;
+      _cachedPath = null;
+      _thumbnailPath = null;
+      _isLoading = false;
+      _status = _Status.idle;
+      updateKeepAlive();
+      _loadThumbnailIfCached();
+    }
+  }
+
+  // Check for a previously generated thumbnail (survives app restarts).
+  Future<void> _loadThumbnailIfCached() async {
+    final thumbFile = await PdfCache.thumbnailFile(widget.event.eventId);
+    if (!mounted) return;
+    if (thumbFile.existsSync()) {
+      setState(() => _thumbnailPath = thumbFile.path);
+    }
+  }
+
+  // Render the first PDF page to a small JPEG and cache it to disk.
+  // Called fire-and-forget — failures are swallowed so they never affect
+  // the main load flow.
+  Future<void> _generateThumbnail(String pdfPath, String eventId) async {
+    try {
+      final thumbFile = await PdfCache.thumbnailFile(eventId);
+
+      // If the thumbnail already exists from a previous run, surface it.
+      if (thumbFile.existsSync()) {
+        if (mounted && _thumbnailPath == null) {
+          setState(() => _thumbnailPath = thumbFile.path);
+        }
+        return;
+      }
+
+      final doc = await PdfDocument.openFile(pdfPath);
+      try {
+        final page = await doc.getPage(1);
+        try {
+          if (page.width <= 0) return;
+
+          const thumbWidth = 200.0;
+          final thumbHeight = page.height * thumbWidth / page.width;
+
+          final image = await page.render(
+            width: thumbWidth,
+            height: thumbHeight,
+            format: PdfPageImageFormat.jpeg,
+            backgroundColor: '#ffffff',
+          );
+
+          if (image != null) {
+            await thumbFile.writeAsBytes(image.bytes);
+            if (mounted) setState(() => _thumbnailPath = thumbFile.path);
+          }
+        } finally {
+          await page.close();
+        }
+      } finally {
+        await doc.close();
+      }
+    } catch (_) {
+      // Thumbnail is best-effort. Never surface this error.
+    }
+  }
+
+  Future<void> _load() async {
+    if (_isLoading || _status == _Status.ready) return;
+    _isLoading = true;
+
+    final event = widget.event;
+    final fileSize = event.infoMap['size'] as int?;
+
+    if (fileSize != null && fileSize > PdfCache.maxFileSizeForInlinePreview) {
+      _isLoading = false;
+      if (context.mounted) await event.saveFile(context);
+      return;
+    }
+
+    try {
+      // Compute path once — avoids TOCTOU between an isCached check and use.
+      final file = await PdfCache.cacheFile(event.eventId);
+      if (!mounted) return;
+
+      if (!file.existsSync()) {
+        final result = await showFutureLoadingDialog<MatrixFile>(
+          context: context,
+          futureWithProgress: (onProgress) =>
+              event.downloadAndDecryptAttachment(
+                onDownloadProgress: fileSize == null
+                    ? null
+                    : (bytes) => onProgress(bytes / fileSize),
+              ),
+        );
+        if (!context.mounted) return;
+        final matrixFile = result.result;
+        if (matrixFile == null) {
+          setState(() => _isLoading = false);
+          return;
+        }
+        await file.writeAsBytes(matrixFile.bytes);
+      }
+
+      if (!mounted) return;
+
+      // Generate thumbnail in background — does not block opening the viewer.
+      _generateThumbnail(file.path, event.eventId).ignore();
+
+      final document = await PdfDocument.openFile(file.path);
+      if (!mounted) return;
+      final controller = PdfController(document: Future.value(document));
+      setState(() {
+        _cachedPath = file.path;
+        _controller = controller;
+        _status = _Status.ready;
+        _isLoading = false;
+      });
+      updateKeepAlive();
+    } catch (_) {
+      if (!mounted) return;
+      setState(() {
+        _status = _Status.error;
+        _isLoading = false;
+      });
+    }
+  }
+
+  void _openFullscreen() {
+    final path = _cachedPath;
+    if (path == null) return;
+    showDialog(
+      context: context,
+      builder: (_) => PdfViewerScreen(filePath: path, event: widget.event),
+    );
+  }
+
+  @override
+  void dispose() {
+    _controller?.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    super.build(context); // required by AutomaticKeepAliveClientMixin
+    return switch (_status) {
+      _Status.idle => _PdfIdleView(
+        event: widget.event,
+        style: widget.style,
+        onTap: _isLoading ? null : _load,
+        thumbnailPath: _thumbnailPath,
+      ),
+      _Status.ready => RepaintBoundary(
+        child: _PdfReadyView(
+          controller: _controller!,
+          style: widget.style,
+          onTap: _openFullscreen,
+        ),
+      ),
+      _Status.error => _PdfIdleView(
+        event: widget.event,
+        style: widget.style,
+        onTap: () => widget.event.saveFile(context),
+        isError: true,
+      ),
+    };
+  }
+}
+
+class _PdfIdleView extends StatelessWidget {
+  final Event event;
+  final AttachmentStyle style;
+  final VoidCallback? onTap;
+  final bool isError;
+  final String? thumbnailPath;
+
+  const _PdfIdleView({
+    required this.event,
+    required this.style,
+    required this.onTap,
+    this.isError = false,
+    this.thumbnailPath,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final filename = event.content.tryGet<String>('filename') ?? event.body;
+    final sizeString = event.sizeString ?? '?MB';
+    final textColor = style.textColor;
+    final thumb = thumbnailPath;
+
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        borderRadius: BorderRadius.circular(AppConfig.borderRadius / 2),
+        onTap: onTap,
+        child: Container(
+          width: 400,
+          padding: const EdgeInsets.all(16),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            spacing: 16,
+            children: [
+              // Thumbnail when cached; generic icon otherwise.
+              if (thumb != null && !isError)
+                ClipRRect(
+                  borderRadius: BorderRadius.circular(4),
+                  child: Image.file(
+                    File(thumb),
+                    width: 40,
+                    height: 56,
+                    fit: BoxFit.cover,
+                    // Decode at display size to avoid holding a 200 px bitmap
+                    // in memory for a 40 px slot.
+                    cacheWidth: 40,
+                    // Fall back to icon if the thumbnail file is corrupted.
+                    errorBuilder: (_, e, s) =>
+                        _PdfIcon(textColor: textColor, isError: isError),
+                  ),
+                )
+              else
+                _PdfIcon(textColor: textColor, isError: isError),
+              Flexible(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(
+                      filename,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: TextStyle(
+                        color: textColor,
+                        fontWeight: FontWeight.w500,
+                      ),
+                    ),
+                    Text(
+                      '$sizeString | PDF',
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: TextStyle(color: textColor, fontSize: 10),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _PdfIcon extends StatelessWidget {
+  final Color textColor;
+  final bool isError;
+
+  const _PdfIcon({required this.textColor, required this.isError});
+
+  @override
+  Widget build(BuildContext context) {
+    return CircleAvatar(
+      backgroundColor: textColor.withAlpha(32),
+      child: Icon(
+        isError ? Icons.file_download_outlined : Icons.picture_as_pdf_outlined,
+        color: textColor,
+      ),
+    );
+  }
+}
+
+class _PdfReadyView extends StatelessWidget {
+  final PdfController controller;
+  final AttachmentStyle style;
+  final VoidCallback onTap;
+
+  const _PdfReadyView({
+    required this.controller,
+    required this.style,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      // opaque ensures taps register even if pdfx internals absorb pointer
+      // events from the frozen-physics PdfView.
+      behavior: HitTestBehavior.opaque,
+      child: ClipRRect(
+        borderRadius: style.borderRadius,
+        child: SizedBox(
+          width: 300,
+          height: 300,
+          // NeverScrollableScrollPhysics prevents the inline PDF from
+          // consuming vertical scroll events and fighting the chat ListView.
+          child: PdfView(
+            controller: controller,
+            scrollDirection: Axis.vertical,
+            physics: const NeverScrollableScrollPhysics(),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/chat/events/pdf/pdf_cache.dart
+++ b/lib/pages/chat/events/pdf/pdf_cache.dart
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2019-Present Christian Kußowski
+// SPDX-FileCopyrightText: 2019-Present Contributors to FluffyChat
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import 'dart:io';
+
+import 'package:path_provider/path_provider.dart';
+
+class PdfCache {
+  // Files above this limit fall back to external-app download.
+  static const int maxFileSizeForInlinePreview = 50 * 1024 * 1024; // 50 MB
+
+  static Directory? _dir;
+
+  static Future<File> cacheFile(String eventId) async {
+    _dir = await _validatedDir();
+    return File('${_dir!.path}/$eventId.pdf');
+  }
+
+  // First-page JPEG thumbnail, generated once and reused across sessions.
+  static Future<File> thumbnailFile(String eventId) async {
+    _dir = await _validatedDir();
+    return File('${_dir!.path}/${eventId}_thumb.jpg');
+  }
+
+  // Re-creates the cache directory if the OS has purged it (e.g. iOS memory
+  // pressure). Checking existsSync() on every call is cheap and prevents
+  // writeAsBytes() failures against a stale cached path.
+  static Future<Directory> _validatedDir() async {
+    final current = _dir;
+    if (current != null && current.existsSync()) return current;
+    return _createDir();
+  }
+
+  static Future<Directory> _createDir() async {
+    final tmp = await getTemporaryDirectory();
+    final dir = Directory('${tmp.path}/fluffychat/pdf');
+    if (!dir.existsSync()) {
+      dir.createSync(recursive: true);
+    }
+    return dir;
+  }
+}

--- a/lib/pages/chat/events/pdf/pdf_viewer_screen.dart
+++ b/lib/pages/chat/events/pdf/pdf_viewer_screen.dart
@@ -1,0 +1,110 @@
+// SPDX-FileCopyrightText: 2019-Present Christian Kußowski
+// SPDX-FileCopyrightText: 2019-Present Contributors to FluffyChat
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import 'dart:io';
+
+import 'package:file_picker/file_picker.dart';
+import 'package:fluffychat/l10n/l10n.dart';
+import 'package:flutter/material.dart';
+import 'package:matrix/matrix.dart';
+import 'package:pdfx/pdfx.dart';
+import 'package:share_plus/share_plus.dart';
+
+class PdfViewerScreen extends StatefulWidget {
+  final String filePath;
+  final Event event;
+
+  const PdfViewerScreen({
+    required this.filePath,
+    required this.event,
+    super.key,
+  });
+
+  @override
+  State<PdfViewerScreen> createState() => _PdfViewerScreenState();
+}
+
+class _PdfViewerScreenState extends State<PdfViewerScreen> {
+  late final PdfControllerPinch _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = PdfControllerPinch(
+      document: PdfDocument.openFile(widget.filePath),
+    );
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  String get _filename {
+    final name =
+        widget.event.content.tryGet<String>('filename') ?? widget.event.body;
+    return name.endsWith('.pdf') ? name : '$name.pdf';
+  }
+
+  Future<void> _save() async {
+    final l10n = L10n.of(context);
+    final bytes = await File(widget.filePath).readAsBytes();
+    if (!mounted) return;
+    final savedPath = await FilePicker.saveFile(
+      dialogTitle: l10n.saveFile,
+      fileName: _filename,
+      bytes: bytes,
+    );
+    if (savedPath == null) return;
+    if (!mounted) return;
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text(l10n.fileHasBeenSavedAt(savedPath))));
+  }
+
+  Future<void> _share() async {
+    await SharePlus.instance.share(
+      ShareParams(
+        files: [
+          XFile(widget.filePath, name: _filename, mimeType: 'application/pdf'),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = L10n.of(context);
+    return Scaffold(
+      appBar: AppBar(
+        leading: CloseButton(onPressed: Navigator.of(context).pop),
+        title: Text(_filename, maxLines: 1, overflow: TextOverflow.ellipsis),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.share_outlined),
+            tooltip: l10n.share,
+            onPressed: _share,
+          ),
+          IconButton(
+            icon: const Icon(Icons.file_download_outlined),
+            tooltip: l10n.saveFile,
+            onPressed: _save,
+          ),
+        ],
+      ),
+      body: PdfViewPinch(
+        controller: _controller,
+        builders: PdfViewPinchBuilders<DefaultBuilderOptions>(
+          options: const DefaultBuilderOptions(),
+          documentLoaderBuilder: (_) =>
+              const Center(child: CircularProgressIndicator.adaptive()),
+          pageLoaderBuilder: (_) =>
+              const Center(child: CircularProgressIndicator.adaptive()),
+        ),
+      ),
+    );
+  }
+}

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -23,6 +23,7 @@ import just_audio
 import open_file_mac
 import package_info_plus
 import pasteboard
+import pdfx
 import record_macos
 import screen_retriever_macos
 import share_plus
@@ -54,6 +55,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   OpenFilePlugin.register(with: registry.registrar(forPlugin: "OpenFilePlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   PasteboardPlugin.register(with: registry.registrar(forPlugin: "PasteboardPlugin"))
+  PdfxPlugin.register(with: registry.registrar(forPlugin: "PdfxPlugin"))
   RecordMacOsPlugin.register(with: registry.registrar(forPlugin: "RecordMacOsPlugin"))
   ScreenRetrieverMacosPlugin.register(with: registry.registrar(forPlugin: "ScreenRetrieverMacosPlugin"))
   SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -353,6 +353,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.4.0"
+  extension:
+    dependency: transitive
+    description:
+      name: extension
+      sha256: be3a6b7f8adad2f6e2e8c63c895d19811fcf203e23466c6296267941d0ff4f24
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.0"
   fake_async:
     dependency: transitive
     description:
@@ -1332,6 +1340,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
+  pdfx:
+    dependency: "direct main"
+    description:
+      name: pdfx
+      sha256: "29db9b71d46bf2335e001f91693f2c3fbbf0760e4c2eb596bf4bafab211471c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.9.2"
   petitparser:
     dependency: transitive
     description:
@@ -1340,6 +1356,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.2"
+  photo_view:
+    dependency: transitive
+    description:
+      name: photo_view
+      sha256: "1fc3d970a91295fbd1364296575f854c9863f225505c28c46e0a03e48960c75e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.15.0"
   platform:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -63,6 +63,7 @@ dependencies:
   pasteboard: ^0.5.0
   path: ^1.9.0
   path_provider: ^2.1.2
+  pdfx: ^2.9.0
   pretty_qr_code: ^3.6.0
   provider: ^6.0.2
   punycode: ^1.0.0

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -15,6 +15,7 @@
 #include <flutter_webrtc/flutter_web_r_t_c_plugin.h>
 #include <geolocator_windows/geolocator_windows.h>
 #include <pasteboard/pasteboard_plugin.h>
+#include <pdfx/pdfx_plugin.h>
 #include <record_windows/record_windows_plugin_c_api.h>
 #include <screen_retriever_windows/screen_retriever_windows_plugin_c_api.h>
 #include <share_plus/share_plus_windows_plugin_c_api.h>
@@ -42,6 +43,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("GeolocatorWindows"));
   PasteboardPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("PasteboardPlugin"));
+  PdfxPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("PdfxPlugin"));
   RecordWindowsPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("RecordWindowsPluginCApi"));
   ScreenRetrieverWindowsPluginCApiRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -12,6 +12,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   flutter_webrtc
   geolocator_windows
   pasteboard
+  pdfx
   record_windows
   screen_retriever_windows
   share_plus


### PR DESCRIPTION
I built this feature with the help of Claude Code. I couldn't find any guidelines against AI-assisted contributions, so I hope that's fine. I've been missing inline PDF viewing in FluffyChat for a while and wanted to contribute it, even though I'm not a Dart/Flutter developer by trade. Happy to iterate on any feedback.

Web inline PDF rendering is currently disabled: I wasn't able to test it properly. The pdfx web plugin is already included and the platform guard in DefaultAttachmentRenderer can be removed to enable it once pdf.js is set up and tested.

----

Introduces a MIME-aware attachment rendering layer and a dedicated PDF preview pipeline using pdfx. PDFs render inline in the chat bubble (tap to load, tap again for fullscreen pinch-zoom viewer) with a 50 MB fallback to the external OS viewer.

Verified on Android. iOS uses the same native renderer path. Linux and Web fall back to the external OS viewer.

Web PDF rendering is intentionally disabled for now. The pdfx web plugin is included in the build but not activated. Web inline PDF can be enabled in a follow-up by adding pdf.js and removing the web guard in DefaultAttachmentRenderer.

Also includes:
- First-page thumbnail cached to disk, shown in idle state on revisit
- AutomaticKeepAliveClientMixin to preserve loaded state across scrolls
- NeverScrollableScrollPhysics to prevent nested scroll conflicts
- Re-entry guard against concurrent download calls
- RepaintBoundary to isolate PDF rasterisation from chat list repaints
- PdfCache stale-path guard for iOS temp-dir purges
- Page resource always released via finally block in thumbnail generator
- cacheWidth hint on thumbnail Image to decode at display size
- Loading spinner in fullscreen viewer while document initialises

Fixes: #1477

- [x] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [x] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desk
- [ ] Desktop Windows
- [ ] Desktop macOS

<img width="576" height="1280" alt="photo_4_2026-05-31_11-14-45" src="https://github.com/user-attachments/assets/413f5a78-6940-4046-a3ca-11be5a47f300" />
<img width="576" height="1280" alt="photo_3_2026-05-31_11-14-45" src="https://github.com/user-attachments/assets/7f093893-d116-4cf3-8af0-b98fcff45596" />
<img width="576" height="1280" alt="photo_2_2026-05-31_11-14-45" src="https://github.com/user-attachments/assets/7b7116f0-a181-45d9-bd7b-914292fba95a" />
<img width="576" height="1280" alt="photo_1_2026-05-31_11-14-45" src="https://github.com/user-attachments/assets/dfca0dd1-d0b7-44db-a098-17b300e3f8d0" />


