### PR TITLE
fix(chat): compact HTML message rendering

### DIFF
--- a/lib/pages/chat/events/html_message.dart
+++ b/lib/pages/chat/events/html_message.dart
@@ -105,6 +105,7 @@ class HtmlMessage extends StatelessWidget {
     'table',
     'details',
     'blockquote',
+    'li',  // <li> 之间换行，避免挤一行
   };
 
   /// We add line breaks before these tags:
@@ -115,7 +116,7 @@ class HtmlMessage extends StatelessWidget {
     'h4',
     'h5',
     'h6',
-    'li',
+    // 'li' 故意不放：让 <li> 走 blockHtmlTags 的 '\n' 分隔，避免 3 个 li 挤一行
   };
 
   /// Adding line breaks before block elements.
@@ -134,7 +135,7 @@ class HtmlMessage extends StatelessWidget {
             onlyElements.indexOf(nodes[i] as dom.Element) <
                 onlyElements.length - 1) ...[
           if (blockHtmlTags.contains((nodes[i] as dom.Element).localName))
-            const TextSpan(text: '\n\n'),
+            const TextSpan(text: '\n'),  // 紧凑化：原 '\n\n' -> '\n'，段间 1 个空行
           if (fullLineHtmlTag.contains((nodes[i] as dom.Element).localName))
             const TextSpan(text: '\n'),
         ],
@@ -182,7 +183,12 @@ class HtmlMessage extends StatelessWidget {
 
     switch (node.localName) {
       case 'br':
-        return const TextSpan(text: '\n');
+        // 紧凑化：用固定高度 WidgetSpan 替代 '\n'，避免 Flutter 文本行高撑大间距
+        return WidgetSpan(
+          alignment: PlaceholderAlignment.baseline,
+          baseline: TextBaseline.alphabetic,
+          child: SizedBox(width: 0, height: fontSize * 0.4),
+        );
       case 'a':
         final href = node.attributes['href'];
         if (href == null) continue block;


### PR DESCRIPTION
I noticed a few rough edges in `HtmlMessage` while testing markdown
rendering on Android:

1. Multi-line `<li>` lists collapsed to a single line — `<li>` only
   lived in `fullLineHtmlTag`, so consecutive items had no separator.
2. The block-element separator was `'\n\n'`, which gave two empty
   lines between paragraphs.
3. `<br>` was rendered as plain `'\n'`, so Flutter's line-height
   multiplier inflated every soft break.

The fix moves `<li>` to `allowedHtmlTags` (so it uses the
`blockHtmlTags` `'\n'` delimiter), reduces the block separator to
`'\n'`, and replaces `<br>` `'\n'` with a `WidgetSpan` of fixed
height (`fontSize * 0.4`).

Tested on Android 16 / Flutter 3.44, see attached screenshots.
