### PR TITLE
feat: Add per-message timestamps

### DIFF
--- a/lib/config/setting_keys.dart
+++ b/lib/config/setting_keys.dart
@@ -76,6 +76,7 @@ enum AppSettings<T> {
   chatFilter<String>('chat.fluffy.chat_filter', 'allChats'),
   hideRoomsInSpaces<bool>('chat.fluffy.hideRoomsInSpaces', false),
   showThumbnailsInTimeline<bool>('chat.fluffy.showThumbnailsInTimeline', true),
+  showMessageTimestamp<bool>('chat.fluffy.showMessageTimestamp', true),
   debugPush<bool>('chat.fluffy.debug_push', false);
 
   final String key;

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -2721,6 +2721,7 @@
     "hideRoomsInSpaces": "Hide rooms that are in a space",
     "possibleByYou": "This release was only possible thanks to your support. FluffyChat remains free, open-source, and entirely community-driven.",
     "showThumbnailsInTimeline": "Show thumbnails of images and videos",
+    "showMessageTimestamp": "Show timestamp on every message",
     "appSubtitle": "Secure [matrix] Communication",
     "appDescription": "Communicate encrypted over the decentralized [matrix] network in an easy and accessible way for everyone.",
     "interactiveVerification": "Interactive verification",

--- a/lib/pages/chat/events/message.dart
+++ b/lib/pages/chat/events/message.dart
@@ -131,6 +131,11 @@ class Message extends StatelessWidget {
         previousEvent!.senderId == event.senderId &&
         previousEvent!.originServerTs.sameEnvironment(event.originServerTs);
 
+    final sameTimestampAsPrevious =
+        previousEventSameSender &&
+        previousEvent!.originServerTs.hour == event.originServerTs.hour &&
+        previousEvent!.originServerTs.minute == event.originServerTs.minute;
+
     final textColor = ownMessage
         ? theme.onBubbleColor
         : theme.colorScheme.onSurface;
@@ -550,43 +555,6 @@ class Message extends StatelessWidget {
                                                 selected: selected,
                                                 bigEmojis: bigEmojis,
                                               ),
-                                              if (event.hasAggregatedEvents(
-                                                timeline,
-                                                RelationshipTypes.edit,
-                                              ))
-                                                Padding(
-                                                  padding:
-                                                      const EdgeInsets.only(
-                                                        bottom: 8.0,
-                                                        left: 16.0,
-                                                        right: 16.0,
-                                                      ),
-                                                  child: Row(
-                                                    mainAxisSize:
-                                                        MainAxisSize.min,
-                                                    spacing: 4.0,
-                                                    children: [
-                                                      Icon(
-                                                        Icons.edit_outlined,
-                                                        color: textColor
-                                                            .withAlpha(164),
-                                                        size: 14,
-                                                      ),
-                                                      Text(
-                                                        displayEvent
-                                                            .originServerTs
-                                                            .localizedTimeShort(
-                                                              context,
-                                                            ),
-                                                        style: TextStyle(
-                                                          color: textColor
-                                                              .withAlpha(164),
-                                                          fontSize: 11,
-                                                        ),
-                                                      ),
-                                                    ],
-                                                  ),
-                                                ),
                                             ],
                                           ),
                                         ),
@@ -799,6 +767,14 @@ class Message extends StatelessWidget {
                           child: MessageReactions(event, timeline),
                         ),
                 ),
+                if ((AppSettings.showMessageTimestamp.value &&
+                        !sameTimestampAsPrevious) ||
+                    event.hasAggregatedEvents(timeline, RelationshipTypes.edit))
+                  _MessageTimestamp(
+                    event: event,
+                    displayEvent: displayEvent,
+                    timeline: timeline,
+                  ),
                 if (enterThread != null)
                   AnimatedSize(
                     duration: FluffyThemes.animationDuration,
@@ -977,6 +953,38 @@ class __AnimateInState extends State<_AnimateIn> {
       duration: FluffyThemes.animationDuration,
       curve: FluffyThemes.animationCurve,
       child: _animationFinished ? widget.child : const SizedBox.shrink(),
+    );
+  }
+}
+
+class _MessageTimestamp extends StatelessWidget {
+  final Event event;
+  final Event displayEvent;
+  final Timeline timeline;
+
+  const _MessageTimestamp({
+    required this.event,
+    required this.displayEvent,
+    required this.timeline,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final color = Theme.of(context).colorScheme.onSurface.withAlpha(128);
+    return Padding(
+      padding: const EdgeInsets.only(top: 2, bottom: 2),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        spacing: 4.0,
+        children: [
+          if (event.hasAggregatedEvents(timeline, RelationshipTypes.edit))
+            Icon(Icons.edit_outlined, color: color, size: 14),
+          Text(
+            displayEvent.originServerTs.localizedTimeOfDay(context),
+            style: TextStyle(color: color, fontSize: 11),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/pages/settings_chat/settings_chat_view.dart
+++ b/lib/pages/settings_chat/settings_chat_view.dart
@@ -69,6 +69,10 @@ class SettingsChatView extends StatelessWidget {
                 title: L10n.of(context).showThumbnailsInTimeline,
                 setting: AppSettings.showThumbnailsInTimeline,
               ),
+              SettingsSwitchListTile.adaptive(
+                title: L10n.of(context).showMessageTimestamp,
+                setting: AppSettings.showMessageTimestamp,
+              ),
               Divider(color: theme.dividerColor),
               ListTile(
                 title: Text(


### PR DESCRIPTION
- [x] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [x] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS


This is the easiest way you can add timestamps to messages without breaking the coding style meaning using StatelessWidget and just override the "build". It even reduces code complexity from my point of view. I searched for a way to make it look like Element-X or WhatsApp, but this from my point of view is only possible with a custom RenderBox (I guess you would not accept that). Otherwise you have to reserve extra space in the bubble and you cant put the time to "half of the text" height. The issue I can reference here is https://github.com/krille-chan/fluffychat/issues/1294