### PR TITLE
feat: auto-detect RTL/LTR text direction per line

### DIFF
--- a/lib/pages/chat/chat_app_bar_list_tile.dart
+++ b/lib/pages/chat/chat_app_bar_list_tile.dart
@@ -5,7 +5,7 @@
 
 import 'package:fluffychat/utils/url_launcher.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_linkify/flutter_linkify.dart';
+import 'package:fluffychat/widgets/auto_linkify.dart';
 
 class ChatAppBarListTile extends StatelessWidget {
   final Widget? leading;
@@ -38,7 +38,7 @@ class ChatAppBarListTile extends StatelessWidget {
             Expanded(
               child: Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 4.0),
-                child: Linkify(
+                child: AutoLinkify(
                   text: title,
                   textScaleFactor: MediaQuery.textScalerOf(context).scale(1),
                   options: const LinkifyOptions(humanize: false),

--- a/lib/pages/chat/events/audio_player.dart
+++ b/lib/pages/chat/events/audio_player.dart
@@ -15,7 +15,7 @@ import 'package:fluffychat/utils/localized_exception_extension.dart';
 import 'package:fluffychat/utils/url_launcher.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_linkify/flutter_linkify.dart';
+import 'package:fluffychat/widgets/auto_linkify.dart';
 import 'package:just_audio/just_audio.dart';
 import 'package:matrix/matrix.dart';
 import 'package:opus_caf_converter_dart/opus_caf_converter_dart.dart';
@@ -490,7 +490,7 @@ class AudioPlayerState extends State<AudioPlayerWidget> {
                         horizontal: 16,
                         vertical: 8,
                       ),
-                      child: Linkify(
+                      child: AutoLinkify(
                         text: fileDescription,
                         textScaleFactor: MediaQuery.textScalerOf(
                           context,

--- a/lib/pages/chat/events/html_message.dart
+++ b/lib/pages/chat/events/html_message.dart
@@ -9,6 +9,7 @@ import 'package:fluffychat/config/themes.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/utils/code_highlight_theme.dart';
 import 'package:fluffychat/utils/event_checkbox_extension.dart';
+import 'package:fluffychat/utils/text_direction.dart';
 import 'package:fluffychat/widgets/avatar.dart';
 import 'package:fluffychat/widgets/future_loading_dialog.dart';
 import 'package:fluffychat/widgets/mxc_image.dart';
@@ -172,11 +173,28 @@ class HtmlMessage extends StatelessWidget {
       // Single linebreak nodes between Elements are ignored:
       if (text == '\n') text = '';
 
-      return LinkifySpan(
-        text: text,
-        options: const LinkifyOptions(humanize: false),
-        linkStyle: linkStyle,
-        onOpen: onOpen,
+      if (!text.contains('\n')) {
+        return LinkifySpan(
+          text: bidiIsolate(text),
+          options: const LinkifyOptions(humanize: false),
+          linkStyle: linkStyle,
+          onOpen: onOpen,
+        );
+      }
+
+      final lines = text.split('\n');
+      return TextSpan(
+        children: [
+          for (var i = 0; i < lines.length; i++) ...[
+            LinkifySpan(
+              text: bidiIsolate(lines[i]),
+              options: const LinkifyOptions(humanize: false),
+              linkStyle: linkStyle,
+              onOpen: onOpen,
+            ),
+            if (i < lines.length - 1) const TextSpan(text: '\n'),
+          ],
+        ],
       );
     }
 
@@ -582,43 +600,142 @@ class HtmlMessage extends StatelessWidget {
     }
   }
 
+  static const Set<String> _blockLevelHtmlTags = {
+    ...blockHtmlTags,
+    ...fullLineHtmlTag,
+    'img',
+    'hr',
+    'thead',
+    'tbody',
+    'tfoot',
+    'tr',
+    'th',
+    'td',
+    'caption',
+  };
+
   @override
   Widget build(BuildContext context) {
     final element = parser.parse(html).body ?? dom.Element.html('');
     final configuredMaxLines = AppSettings.messagePreviewMaxLines.value;
     final maxLines = configuredMaxLines <= 0 ? null : configuredMaxLines;
-    final span = _renderHtml(element, context);
     final style = TextStyle(fontSize: fontSize, color: textColor);
-
-    if (maxLines == null) {
-      return Text.rich(
-        span,
-        style: style,
-        selectionColor: textColor.withAlpha(128),
-      );
-    }
-
-    // Heuristic: if plain text has enough newlines or length, it will overflow.
     final plainText = element.text;
-    final lineCount = '\n'.allMatches(plainText).length + 1;
-    final likelyOverflows =
-        lineCount > maxLines || plainText.length > maxLines * 50;
 
-    if (!likelyOverflows) {
+    final hasBlockElements = element.nodes.any(
+      (n) => n is dom.Element && _blockLevelHtmlTags.contains(n.localName),
+    );
+
+    if (hasBlockElements || !plainText.contains('\n')) {
+      final span = _renderHtml(element, context);
+      if (!hasBlockElements) {
+        final dir = autoTextDirection(plainText);
+        if (maxLines == null) {
+          return Text.rich(
+            span,
+            style: style,
+            textDirection: dir,
+            selectionColor: textColor.withAlpha(128),
+          );
+        }
+        final lineCount = 1;
+        final likelyOverflows = plainText.length > maxLines * 50;
+        if (!likelyOverflows) {
+          return Text.rich(
+            span,
+            style: style,
+            textDirection: dir,
+            selectionColor: textColor.withAlpha(128),
+          );
+        }
+        return _CollapsibleText(
+          span: span,
+          style: style,
+          textColor: textColor,
+          linkColor: linkStyle.color ?? textColor,
+          fontSize: fontSize,
+          maxLines: maxLines,
+        );
+      }
+      if (maxLines == null) {
+        return Text.rich(
+          span,
+          style: style,
+          selectionColor: textColor.withAlpha(128),
+        );
+      }
+      final lineCount = '\n'.allMatches(plainText).length + 1;
+      final likelyOverflows =
+          lineCount > maxLines || plainText.length > maxLines * 50;
+      if (!likelyOverflows) {
+        return Text.rich(
+          span,
+          style: style,
+          selectionColor: textColor.withAlpha(128),
+        );
+      }
+      return _CollapsibleText(
+        span: span,
+        style: style,
+        textColor: textColor,
+        linkColor: linkStyle.color ?? textColor,
+        fontSize: fontSize,
+        maxLines: maxLines,
+      );
+    }
+
+    return _buildPerLine(element, context, style, plainText, maxLines);
+  }
+
+  Widget _buildPerLine(
+    dom.Element body,
+    BuildContext context,
+    TextStyle style,
+    String plainText,
+    int? maxLines,
+  ) {
+    final allLines = plainText.split('\n');
+    final controlledMaxLines =
+        maxLines != null && allLines.length > maxLines ? maxLines : null;
+
+    if (controlledMaxLines != null) {
+      final span = _renderHtml(body, context);
       return Text.rich(
         span,
         style: style,
+        maxLines: controlledMaxLines,
+        overflow: TextOverflow.ellipsis,
         selectionColor: textColor.withAlpha(128),
       );
     }
 
-    return _CollapsibleText(
-      span: span,
-      style: style,
-      maxLines: maxLines,
-      textColor: textColor,
-      linkColor: linkStyle.color ?? textColor,
-      fontSize: fontSize,
+    final widgets = <Widget>[];
+    for (var i = 0; i < allLines.length; i++) {
+      final line = allLines[i];
+      if (line.isEmpty) {
+        widgets.add(SizedBox(height: fontSize * 0.5));
+        continue;
+      }
+
+      final lineElement =
+          parser.parse(line).body ?? dom.Element.html('');
+      final span = _renderHtml(lineElement, context);
+      final dir = autoTextDirection(line);
+
+      widgets.add(
+        Text.rich(
+          span,
+          style: style,
+          textDirection: dir,
+          selectionColor: textColor.withAlpha(128),
+        ),
+      );
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      mainAxisSize: MainAxisSize.min,
+      children: widgets,
     );
   }
 }

--- a/lib/pages/chat/events/image_bubble.dart
+++ b/lib/pages/chat/events/image_bubble.dart
@@ -9,7 +9,7 @@ import 'package:fluffychat/utils/file_description.dart';
 import 'package:fluffychat/utils/url_launcher.dart';
 import 'package:fluffychat/widgets/mxc_image.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_linkify/flutter_linkify.dart';
+import 'package:fluffychat/widgets/auto_linkify.dart';
 import 'package:matrix/matrix.dart';
 
 import '../../../widgets/blur_hash.dart';
@@ -121,7 +121,7 @@ class ImageBubble extends StatelessWidget {
             width: width,
             child: Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-              child: Linkify(
+              child: AutoLinkify(
                 text: fileDescription,
                 textScaleFactor: MediaQuery.textScalerOf(context).scale(1),
                 style: TextStyle(

--- a/lib/pages/chat/events/message_download_content.dart
+++ b/lib/pages/chat/events/message_download_content.dart
@@ -9,7 +9,7 @@ import 'package:fluffychat/utils/file_description.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/event_extension.dart';
 import 'package:fluffychat/utils/url_launcher.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_linkify/flutter_linkify.dart';
+import 'package:fluffychat/widgets/auto_linkify.dart';
 import 'package:matrix/matrix.dart';
 
 class MessageDownloadContent extends StatelessWidget {
@@ -100,7 +100,7 @@ class MessageDownloadContent extends StatelessWidget {
               horizontal: 16.0,
               vertical: 8.0,
             ),
-            child: Linkify(
+            child: AutoLinkify(
               text: fileDescription,
               textScaleFactor: MediaQuery.textScalerOf(context).scale(1),
               style: TextStyle(

--- a/lib/pages/chat/events/poll.dart
+++ b/lib/pages/chat/events/poll.dart
@@ -10,7 +10,7 @@ import 'package:fluffychat/utils/url_launcher.dart';
 import 'package:fluffychat/widgets/avatar.dart';
 import 'package:fluffychat/widgets/future_loading_dialog.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_linkify/flutter_linkify.dart';
+import 'package:fluffychat/widgets/auto_linkify.dart';
 import 'package:matrix/matrix.dart' hide Result;
 
 class PollWidget extends StatelessWidget {
@@ -72,7 +72,7 @@ class PollWidget extends StatelessWidget {
         children: [
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 16),
-            child: Linkify(
+            child: AutoLinkify(
               text: eventContent.pollStartContent.question.mText,
               textScaleFactor: MediaQuery.textScalerOf(context).scale(1),
               style: TextStyle(

--- a/lib/pages/chat/events/video_player.dart
+++ b/lib/pages/chat/events/video_player.dart
@@ -14,7 +14,7 @@ import 'package:fluffychat/utils/url_launcher.dart';
 import 'package:fluffychat/widgets/blur_hash.dart';
 import 'package:fluffychat/widgets/mxc_image.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_linkify/flutter_linkify.dart';
+import 'package:fluffychat/widgets/auto_linkify.dart';
 import 'package:matrix/matrix.dart';
 
 import '../../image_viewer/image_viewer.dart';
@@ -139,7 +139,7 @@ class EventVideoPlayer extends StatelessWidget {
             width: width,
             child: Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-              child: Linkify(
+              child: AutoLinkify(
                 text: fileDescription,
                 textScaleFactor: MediaQuery.textScalerOf(context).scale(1),
                 style: TextStyle(

--- a/lib/pages/chat/input_bar.dart
+++ b/lib/pages/chat/input_bar.dart
@@ -9,6 +9,7 @@ import 'package:fluffychat/config/setting_keys.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pages/chat/trust_user_key_dialog.dart';
 import 'package:fluffychat/utils/markdown_context_builder.dart';
+import 'package:fluffychat/utils/text_direction.dart';
 import 'package:fluffychat/widgets/mxc_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -402,6 +403,7 @@ class InputBar extends StatelessWidget {
           controller: controller,
           focusNode: focusNode,
           readOnly: readOnly,
+          textDirection: autoTextDirection(controller.text),
           onEditingComplete: () {
             // To not lose focus on iOS:
             // https://github.com/krille-chan/fluffychat/issues/2784

--- a/lib/pages/chat_details/chat_details_view.dart
+++ b/lib/pages/chat_details/chat_details_view.dart
@@ -13,7 +13,7 @@ import 'package:fluffychat/widgets/chat_settings_popup_menu.dart';
 import 'package:fluffychat/widgets/layouts/max_width_body.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_linkify/flutter_linkify.dart';
+import 'package:fluffychat/widgets/auto_linkify.dart';
 import 'package:go_router/go_router.dart';
 import 'package:matrix/matrix.dart';
 
@@ -234,7 +234,7 @@ class ChatDetailsView extends StatelessWidget {
                             padding: const EdgeInsets.symmetric(
                               horizontal: 16.0,
                             ),
-                            child: SelectableLinkify(
+                            child: AutoSelectableLinkify(
                               text: room.topic.isEmpty
                                   ? L10n.of(context).noChatDescriptionYet
                                   : room.topic,

--- a/lib/pages/chat_search/chat_search_message_tab.dart
+++ b/lib/pages/chat_search/chat_search_message_tab.dart
@@ -10,7 +10,7 @@ import 'package:fluffychat/utils/matrix_sdk_extensions/matrix_locals.dart';
 import 'package:fluffychat/utils/url_launcher.dart';
 import 'package:fluffychat/widgets/avatar.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_linkify/flutter_linkify.dart';
+import 'package:fluffychat/widgets/auto_linkify.dart';
 import 'package:go_router/go_router.dart';
 import 'package:matrix/matrix.dart';
 
@@ -117,7 +117,7 @@ class _MessageSearchResultListTile extends StatelessWidget {
           ),
         ],
       ),
-      subtitle: Linkify(
+      subtitle: AutoLinkify(
         textScaleFactor: MediaQuery.textScalerOf(context).scale(1),
         options: const LinkifyOptions(humanize: false),
         linkStyle: TextStyle(

--- a/lib/pages/settings_homeserver/settings_homeserver_view.dart
+++ b/lib/pages/settings_homeserver/settings_homeserver_view.dart
@@ -11,7 +11,7 @@ import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/utils/localized_exception_extension.dart';
 import 'package:fluffychat/widgets/layouts/max_width_body.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_linkify/flutter_linkify.dart';
+import 'package:fluffychat/widgets/auto_linkify.dart';
 import 'package:matrix/matrix.dart';
 import 'package:url_launcher/url_launcher_string.dart';
 
@@ -162,7 +162,7 @@ class SettingsHomeserverView extends StatelessWidget {
                       ),
                       ListTile(
                         title: Text(L10n.of(context).federationBaseUrl),
-                        subtitle: Linkify(
+                        subtitle: AutoLinkify(
                           text: data.federationBaseUrl.toString(),
                           textScaleFactor: MediaQuery.textScalerOf(
                             context,
@@ -222,7 +222,7 @@ class SettingsHomeserverView extends StatelessWidget {
                       ),
                       ListTile(
                         title: Text(L10n.of(context).baseUrl),
-                        subtitle: Linkify(
+                        subtitle: AutoLinkify(
                           text: wellKnown.mHomeserver.baseUrl.toString(),
                           textScaleFactor: MediaQuery.textScalerOf(
                             context,
@@ -238,7 +238,7 @@ class SettingsHomeserverView extends StatelessWidget {
                       if (identityServer != null)
                         ListTile(
                           title: Text(L10n.of(context).identityServer),
-                          subtitle: Linkify(
+                          subtitle: AutoLinkify(
                             text: identityServer.baseUrl.toString(),
                             textScaleFactor: MediaQuery.textScalerOf(
                               context,

--- a/lib/utils/text_direction.dart
+++ b/lib/utils/text_direction.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+
+const _rtlRanges = [
+  [0x0590, 0x08FF],
+  [0xFB1D, 0xFDFF],
+  [0xFE70, 0xFEFF],
+  [0x0600, 0x06FF],
+];
+
+const _ltrRanges = [
+  [0x0041, 0x007A],
+  [0x00C0, 0x024F],
+  [0x0370, 0x03FF],
+  [0x0400, 0x04FF],
+];
+
+bool _isRtl(int rune) => _rtlRanges.any((r) => rune >= r[0] && rune <= r[1]) || rune == 0x200F;
+
+bool _isLtr(int rune) => _ltrRanges.any((r) => rune >= r[0] && rune <= r[1]);
+
+TextDirection autoTextDirection(String text) {
+  if (text.isEmpty) return TextDirection.ltr;
+  for (final rune in text.runes) {
+    if (_isRtl(rune)) return TextDirection.rtl;
+    if (_isLtr(rune)) return TextDirection.ltr;
+  }
+  return TextDirection.ltr;
+}
+
+String bidiIsolate(String text) {
+  if (text.isEmpty) return text;
+  if (autoTextDirection(text) == TextDirection.rtl) {
+    return '\u{2067}$text\u{2069}';
+  }
+  return text;
+}
+
+String bidiIsolateMultiline(String text) {
+  if (!text.contains('\n')) return bidiIsolate(text);
+  return text.split('\n').map(bidiIsolate).join('\n');
+}

--- a/lib/widgets/adaptive_dialogs/public_room_dialog.dart
+++ b/lib/widgets/adaptive_dialogs/public_room_dialog.dart
@@ -9,7 +9,7 @@ import 'package:fluffychat/widgets/adaptive_dialogs/show_ok_cancel_alert_dialog.
 import 'package:fluffychat/widgets/adaptive_dialogs/show_text_input_dialog.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter_linkify/flutter_linkify.dart';
+import 'package:fluffychat/widgets/auto_linkify.dart';
 import 'package:go_router/go_router.dart';
 import 'package:matrix/matrix.dart';
 
@@ -220,7 +220,7 @@ class PublicRoomDialog extends StatelessWidget {
                         thumbVisibility: true,
                         trackVisibility: true,
                         child: SingleChildScrollView(
-                          child: SelectableLinkify(
+                          child: AutoSelectableLinkify(
                             text: topic,
                             textScaleFactor: MediaQuery.textScalerOf(
                               context,

--- a/lib/widgets/adaptive_dialogs/show_ok_cancel_alert_dialog.dart
+++ b/lib/widgets/adaptive_dialogs/show_ok_cancel_alert_dialog.dart
@@ -7,7 +7,7 @@ import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/utils/url_launcher.dart';
 import 'package:fluffychat/widgets/adaptive_dialogs/adaptive_dialog_action.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_linkify/flutter_linkify.dart';
+import 'package:fluffychat/widgets/auto_linkify.dart';
 
 enum OkCancelResult { ok, cancel }
 
@@ -31,7 +31,7 @@ Future<OkCancelResult?> showOkCancelAlertDialog({
       constraints: const BoxConstraints(maxWidth: 256),
       child: message == null
           ? null
-          : SelectableLinkify(
+          : AutoSelectableLinkify(
               text: message,
               textScaleFactor: MediaQuery.textScalerOf(context).scale(1),
               linkStyle: TextStyle(
@@ -83,7 +83,7 @@ Future<OkCancelResult?> showOkAlertDialog({
       constraints: const BoxConstraints(maxWidth: 256),
       child: message == null
           ? null
-          : SelectableLinkify(
+          : AutoSelectableLinkify(
               text: message,
               textScaleFactor: MediaQuery.textScalerOf(context).scale(1),
               linkStyle: TextStyle(

--- a/lib/widgets/adaptive_dialogs/show_text_input_dialog.dart
+++ b/lib/widgets/adaptive_dialogs/show_text_input_dialog.dart
@@ -8,7 +8,7 @@ import 'package:fluffychat/utils/url_launcher.dart';
 import 'package:fluffychat/widgets/adaptive_dialogs/adaptive_dialog_action.dart';
 import 'package:fluffychat/widgets/adaptive_dialogs/dialog_text_field.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_linkify/flutter_linkify.dart';
+import 'package:fluffychat/widgets/auto_linkify.dart';
 
 Future<String?> showTextInputDialog({
   required BuildContext context,
@@ -48,7 +48,7 @@ Future<String?> showTextInputDialog({
             mainAxisSize: .min,
             children: [
               if (message != null)
-                SelectableLinkify(
+                AutoSelectableLinkify(
                   text: message,
                   textScaleFactor: MediaQuery.textScalerOf(context).scale(1),
                   linkStyle: TextStyle(

--- a/lib/widgets/adaptive_dialogs/user_dialog.dart
+++ b/lib/widgets/adaptive_dialogs/user_dialog.dart
@@ -13,7 +13,7 @@ import 'package:fluffychat/widgets/avatar.dart';
 import 'package:fluffychat/widgets/presence_builder.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter_linkify/flutter_linkify.dart';
+import 'package:fluffychat/widgets/auto_linkify.dart';
 import 'package:go_router/go_router.dart';
 import 'package:matrix/matrix.dart';
 
@@ -174,7 +174,7 @@ class UserDialog extends StatelessWidget {
                     thumbVisibility: true,
                     trackVisibility: true,
                     child: SingleChildScrollView(
-                      child: SelectableLinkify(
+                      child: AutoSelectableLinkify(
                         text: statusMsg,
                         textScaleFactor: MediaQuery.textScalerOf(
                           context,

--- a/lib/widgets/auto_linkify.dart
+++ b/lib/widgets/auto_linkify.dart
@@ -1,0 +1,157 @@
+import 'package:fluffychat/utils/text_direction.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_linkify/flutter_linkify.dart';
+
+export 'package:flutter_linkify/flutter_linkify.dart'
+    show
+        LinkifyOptions,
+        LinkableElement,
+        LinkCallback,
+        Linkifier,
+        UrlLinkifier,
+        EmailLinkifier,
+        LinkifySpan,
+        LinkifyElement,
+        TextElement,
+        UrlElement,
+        EmailElement;
+
+const _defaultLinkifiers = [UrlLinkifier(), EmailLinkifier()];
+
+class AutoLinkify extends StatelessWidget {
+  final String text;
+  final List<Linkifier> linkifiers;
+  final LinkCallback? onOpen;
+  final LinkifyOptions options;
+  final TextStyle? style;
+  final TextStyle? linkStyle;
+  final TextAlign textAlign;
+  final int? maxLines;
+  final TextOverflow? overflow;
+  final double textScaleFactor;
+  final bool softWrap;
+  final StrutStyle? strutStyle;
+  final Locale? locale;
+  final TextWidthBasis textWidthBasis;
+  final TextHeightBehavior? textHeightBehavior;
+  final bool useMouseRegion;
+
+  const AutoLinkify({
+    super.key,
+    required this.text,
+    this.linkifiers = _defaultLinkifiers,
+    this.onOpen,
+    this.options = const LinkifyOptions(),
+    this.style,
+    this.linkStyle,
+    this.textAlign = TextAlign.start,
+    this.maxLines,
+    this.overflow = TextOverflow.clip,
+    this.textScaleFactor = 1.0,
+    this.softWrap = true,
+    this.strutStyle,
+    this.locale,
+    this.textWidthBasis = TextWidthBasis.parent,
+    this.textHeightBehavior,
+    this.useMouseRegion = true,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Linkify(
+      text: bidiIsolateMultiline(text),
+      linkifiers: linkifiers,
+      onOpen: onOpen,
+      options: options,
+      style: style,
+      linkStyle: linkStyle,
+      textAlign: textAlign,
+      maxLines: maxLines,
+      overflow: overflow,
+      textScaleFactor: textScaleFactor,
+      softWrap: softWrap,
+      strutStyle: strutStyle,
+      locale: locale,
+      textWidthBasis: textWidthBasis,
+      textHeightBehavior: textHeightBehavior,
+      useMouseRegion: useMouseRegion,
+    );
+  }
+}
+
+class AutoSelectableLinkify extends StatelessWidget {
+  final String text;
+  final double textScaleFactor;
+  final List<Linkifier> linkifiers;
+  final LinkCallback? onOpen;
+  final LinkifyOptions options;
+  final TextStyle? style;
+  final TextStyle? linkStyle;
+  final TextAlign? textAlign;
+  final int? minLines;
+  final int? maxLines;
+  final FocusNode? focusNode;
+  final bool showCursor;
+  final bool autofocus;
+  final StrutStyle? strutStyle;
+  final DragStartBehavior dragStartBehavior;
+  final bool enableInteractiveSelection;
+  final SelectionChangedCallback? onSelectionChanged;
+  final ScrollPhysics? scrollPhysics;
+  final TextWidthBasis? textWidthBasis;
+  final TextHeightBehavior? textHeightBehavior;
+  final bool useMouseRegion;
+
+  const AutoSelectableLinkify({
+    super.key,
+    required this.text,
+    this.textScaleFactor = 1.0,
+    this.linkifiers = _defaultLinkifiers,
+    this.onOpen,
+    this.options = const LinkifyOptions(),
+    this.style,
+    this.linkStyle,
+    this.textAlign,
+    this.minLines,
+    this.maxLines,
+    this.focusNode,
+    this.showCursor = false,
+    this.autofocus = false,
+    this.strutStyle,
+    this.dragStartBehavior = DragStartBehavior.start,
+    this.enableInteractiveSelection = true,
+    this.onSelectionChanged,
+    this.scrollPhysics,
+    this.textWidthBasis,
+    this.textHeightBehavior,
+    this.useMouseRegion = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return SelectableLinkify(
+      text: bidiIsolateMultiline(text),
+      textScaleFactor: textScaleFactor,
+      linkifiers: linkifiers,
+      onOpen: onOpen,
+      options: options,
+      style: style,
+      linkStyle: linkStyle,
+      textAlign: textAlign,
+      minLines: minLines,
+      maxLines: maxLines,
+      focusNode: focusNode,
+      showCursor: showCursor,
+      autofocus: autofocus,
+      strutStyle: strutStyle,
+      dragStartBehavior: dragStartBehavior,
+      enableInteractiveSelection: enableInteractiveSelection,
+      onSelectionChanged: onSelectionChanged,
+      scrollPhysics: scrollPhysics,
+      textWidthBasis: textWidthBasis,
+      textHeightBehavior: textHeightBehavior,
+      useMouseRegion: useMouseRegion,
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Adds automatic RTL/LTR text direction detection for messages and the input bar. Each line independently detects its direction from the first strong character, matching Telegram behavior: Arabic/Hebrew/Persian lines right-aligned, English lines left-aligned.

## Why not `.bidiFormatted`?

The previous rejected PR required manually adding `.bidiFormatted` suffix everywhere. This PR is **automatic** — text direction is detected from content using Unicode BiDi isolates (RLI/PDI) at the per-segment level. Developers never think about RTL.

## What changed

| File | Change |
|------|--------|
| `lib/utils/text_direction.dart` (new) | `autoTextDirection()` + `bidiIsolate()` + `bidiIsolateMultiline()` |
| `lib/widgets/auto_linkify.dart` (new) | `AutoLinkify`/`AutoSelectableLinkify` — apply BiDi isolation automatically |
| `lib/pages/chat/events/html_message.dart` | Per-line `Text.rich` widgets with auto direction; BiDi isolates in text nodes |
| `lib/pages/chat/input_bar.dart` | TextField direction switches dynamically as you type |
| 13 Linkify call sites | Switched to AutoLinkify (mechanical rename, same API) |

## Why this is low-maintenance

- **No `.bidiFormatted` suffix** — never think about RTL
- **AutoLinkify has the exact same API as Linkify** — just rename the import
- **Chat message rendering** detects direction per-line in the text node handler automatically
- **17 files changed, 2 new** — the core logic is in `text_direction.dart` (~40 lines)