### PR TITLE
feat: improve caption display for portrait images

### DIFF
--- a/lib/pages/chat/events/message_content.dart
+++ b/lib/pages/chat/events/message_content.dart
@@ -15,6 +15,7 @@ import 'package:matrix/matrix.dart';
 
 import '../../../config/app_config.dart';
 import '../../../utils/event_checkbox_extension.dart';
+import '../../../utils/file_description.dart';
 import '../../../utils/platform_infos.dart';
 import '../../../utils/url_launcher.dart';
 import 'audio_player.dart';
@@ -81,6 +82,10 @@ class MessageContent extends StatelessWidget {
                 height = maxSize;
                 width = max(32, maxSize * (w / h));
               }
+            }
+            if (event.fileDescription != null) {
+              width = maxSize;
+              fit = BoxFit.cover;
             }
             return ImageBubble(
               event,


### PR DESCRIPTION
If a portrait image has a caption, the text gets compressed to the width of the image which often looks bad. Expand to full bubble width and crop the image as a tradeoff. User needs to tap to see the full image.

- [x] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [x] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS