### PR TITLE
feat: implement Android conversation notifications

### DIFF
--- a/android/app/src/main/kotlin/chat/fluffy/fluffychat/ConversationNotifications.kt
+++ b/android/app/src/main/kotlin/chat/fluffy/fluffychat/ConversationNotifications.kt
@@ -1,0 +1,180 @@
+// SPDX-FileCopyrightText: 2019-Present Contributors to FluffyChat
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package chat.fluffy.fluffychat
+
+import android.content.Context
+import android.content.Intent
+import android.graphics.BitmapFactory
+import androidx.core.app.NotificationChannelCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.core.app.Person
+import androidx.core.content.LocusIdCompat
+import androidx.core.content.pm.ShortcutInfoCompat
+import androidx.core.content.pm.ShortcutManagerCompat
+import androidx.core.graphics.drawable.IconCompat
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
+
+/**
+ * Handles Android Conversation Notifications (API 30+).
+ *
+ * Publishes dynamic shortcuts with SHORTCUT_CATEGORY_CONVERSATION so that
+ * MessagingStyle notifications appear in the Android Conversations section.
+ * Also creates per-room notification channels linked to their shortcut via
+ * setConversationId().
+ *
+ * The shortcut intent format is kept compatible with flutter_shortcuts_new so
+ * that FlutterShortcuts().listenAction() in chat_list.dart continues to work.
+ */
+class ConversationNotifications(private val context: Context) : MethodChannel.MethodCallHandler {
+
+    companion object {
+        const val CHANNEL_NAME = "chat.fluffy.fluffychat/conversations"
+
+        // Must match MethodCallImplementation.EXTRA_ACTION in flutter_shortcuts_new
+        private const val SHORTCUT_EXTRA_ACTION = "flutter_shortcuts_new"
+    }
+
+    override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
+        when (call.method) {
+            "publishShortcut" -> publishShortcut(call, result)
+            "removeShortcuts" -> removeShortcuts(call, result)
+            "createConversationChannel" -> createConversationChannel(call, result)
+            "removeConversationChannels" -> removeConversationChannels(call, result)
+            else -> result.notImplemented()
+        }
+    }
+
+    /**
+     * Publishes (or updates) a long-lived dynamic shortcut for a Matrix room.
+     *
+     * Sets SHORTCUT_CATEGORY_CONVERSATION and setLongLived(true) so Android
+     * classifies MessagingStyle notifications linked to this shortcut as
+     * Conversations.  The intent format matches flutter_shortcuts_new so that
+     * tapping the shortcut from the launcher still invokes FluffyChat's
+     * existing UrlLauncher → room navigation flow.
+     */
+    private fun publishShortcut(call: MethodCall, result: MethodChannel.Result) {
+        try {
+            val id = call.argument<String>("id")
+                ?: return result.error("MISSING_ARG", "id required", null)
+            val name = call.argument<String>("name")
+                ?: return result.error("MISSING_ARG", "name required", null)
+            val roomUrl = call.argument<String>("roomUrl")
+                ?: return result.error("MISSING_ARG", "roomUrl required", null)
+            val avatarBytes = call.argument<ByteArray?>("avatar")
+            val isImportant = call.argument<Boolean>("isImportant") ?: false
+
+            // Build the icon from avatar bytes when available.
+            val icon: IconCompat? = avatarBytes
+                ?.takeIf { it.isNotEmpty() }
+                ?.let { BitmapFactory.decodeByteArray(it, 0, it.size) }
+                ?.let { IconCompat.createWithAdaptiveBitmap(it) }
+
+            val person = Person.Builder()
+                .setKey(id)
+                .setName(name)
+                .setImportant(isImportant)
+                .apply { icon?.let { setIcon(it) } }
+                .build()
+
+            // Use ACTION_RUN + SHORTCUT_EXTRA_ACTION so that
+            // FlutterShortcuts().listenAction() in chat_list.dart receives the
+            // room URL and UrlLauncher can open the room.
+            val intent = context.packageManager
+                .getLaunchIntentForPackage(context.packageName)
+                ?.setAction(Intent.ACTION_RUN)
+                ?.putExtra(SHORTCUT_EXTRA_ACTION, roomUrl)
+                ?.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+                ?: return result.error("NO_INTENT", "Could not get launch intent", null)
+
+            val shortcut = ShortcutInfoCompat.Builder(context, id)
+                .setShortLabel(name)
+                .setIntent(intent)
+                .setPerson(person)
+                .setLongLived(true)
+                .setCategories(setOf("android.shortcut.conversation"))
+                .setLocusId(LocusIdCompat(id))
+                .apply { icon?.let { setIcon(it) } }
+                .build()
+
+            ShortcutManagerCompat.pushDynamicShortcut(context, shortcut)
+            result.success(null)
+        } catch (e: Exception) {
+            result.error("SHORTCUT_ERROR", e.message, null)
+        }
+    }
+
+    private fun removeShortcuts(call: MethodCall, result: MethodChannel.Result) {
+        try {
+            val ids = call.argument<List<String>>("ids")
+                ?: return result.error("MISSING_ARG", "ids required", null)
+            ShortcutManagerCompat.removeDynamicShortcuts(context, ids)
+            result.success(null)
+        } catch (e: Exception) {
+            result.error("SHORTCUT_ERROR", e.message, null)
+        }
+    }
+
+    /**
+     * Creates a per-room notification channel with setConversationId() so that
+     * Android Settings shows conversation-specific channel controls.
+     *
+     * On API < 30 setConversationId() is a no-op via the AndroidX compat layer;
+     * the channel still works correctly for grouping purposes.
+     *
+     * If the channel with the given id already exists (e.g. created by an older
+     * app version without setConversationId), this call is a no-op and the
+     * existing channel is preserved.
+     */
+    private fun createConversationChannel(call: MethodCall, result: MethodChannel.Result) {
+        try {
+            val id = call.argument<String>("id")
+                ?: return result.error("MISSING_ARG", "id required", null)
+            val name = call.argument<String>("name")
+                ?: return result.error("MISSING_ARG", "name required", null)
+            val groupId = call.argument<String?>("groupId")
+            val parentChannelId = call.argument<String>("parentChannelId")
+                ?: return result.error("MISSING_ARG", "parentChannelId required", null)
+            val shortcutId = call.argument<String>("shortcutId")
+                ?: return result.error("MISSING_ARG", "shortcutId required", null)
+
+            val notificationManager = NotificationManagerCompat.from(context)
+
+            // Skip if channel already exists to preserve any user customisations.
+            if (notificationManager.getNotificationChannel(id) != null) {
+                return result.success(null)
+            }
+
+            val channel = NotificationChannelCompat.Builder(
+                id,
+                NotificationManagerCompat.IMPORTANCE_HIGH,
+            )
+                .setName(name)
+                .apply { groupId?.let { setGroup(it) } }
+                .setConversationId(parentChannelId, shortcutId)
+                .build()
+
+            notificationManager.createNotificationChannel(channel)
+            result.success(null)
+        } catch (e: Exception) {
+            result.error("CHANNEL_ERROR", e.message, null)
+        }
+    }
+
+    private fun removeConversationChannels(call: MethodCall, result: MethodChannel.Result) {
+        try {
+            val ids = call.argument<List<String>>("ids")
+                ?: return result.error("MISSING_ARG", "ids required", null)
+            val notificationManager = NotificationManagerCompat.from(context)
+            for (channelId in ids) {
+                notificationManager.deleteNotificationChannel(channelId)
+            }
+            result.success(null)
+        } catch (e: Exception) {
+            result.error("CHANNEL_ERROR", e.message, null)
+        }
+    }
+}

--- a/android/app/src/main/kotlin/chat/fluffy/fluffychat/MainActivity.kt
+++ b/android/app/src/main/kotlin/chat/fluffy/fluffychat/MainActivity.kt
@@ -2,6 +2,7 @@ package chat.fluffy.fluffychat
 
 import io.flutter.embedding.android.FlutterFragmentActivity
 import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.MethodChannel
 
 import android.content.Context
 
@@ -18,6 +19,10 @@ class MainActivity : FlutterFragmentActivity() {
 
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
         // do nothing, because the engine was been configured in provideEngine
+        MethodChannel(
+            flutterEngine.dartExecutor.binaryMessenger,
+            ConversationNotifications.CHANNEL_NAME,
+        ).setMethodCallHandler(ConversationNotifications(this))
     }
 
     companion object {

--- a/lib/utils/android_conversation_notifications.dart
+++ b/lib/utils/android_conversation_notifications.dart
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: 2019-Present Contributors to FluffyChat
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import 'package:fluffychat/utils/platform_infos.dart';
+import 'package:flutter/services.dart';
+
+/// Dart wrapper around the native Android ConversationNotifications
+/// MethodChannel.  All methods are no-ops on non-Android platforms.
+class AndroidConversationNotifications {
+  static const _channel = MethodChannel('chat.fluffy.fluffychat/conversations');
+
+  /// Publishes (or updates) a long-lived dynamic shortcut for a Matrix room
+  /// with SHORTCUT_CATEGORY_CONVERSATION so that Android classifies linked
+  /// MessagingStyle notifications as Conversations.
+  static Future<void> publishShortcut({
+    required String id,
+    required String name,
+    required String roomUrl,
+    Uint8List? avatar,
+    bool isImportant = false,
+  }) async {
+    if (!PlatformInfos.isAndroid) return;
+    try {
+      await _channel.invokeMethod<void>('publishShortcut', {
+        'id': id,
+        'name': name,
+        'roomUrl': roomUrl,
+        'avatar': ?avatar,
+        'isImportant': isImportant,
+      });
+    } on PlatformException catch (e) {
+      // Non-fatal: notification still shows without conversation shortcut.
+      throw Exception('publishShortcut failed: ${e.message}');
+    }
+  }
+
+  static Future<void> removeShortcuts(List<String> ids) async {
+    if (!PlatformInfos.isAndroid || ids.isEmpty) return;
+    await _channel.invokeMethod<void>('removeShortcuts', {'ids': ids});
+  }
+
+  /// Creates a per-room notification channel linked to its shortcut via
+  /// setConversationId() so Android Settings shows per-conversation controls.
+  /// If the channel already exists this is a no-op.
+  static Future<void> createConversationChannel({
+    required String id,
+    required String name,
+    String? groupId,
+    required String parentChannelId,
+    required String shortcutId,
+  }) async {
+    if (!PlatformInfos.isAndroid) return;
+    await _channel.invokeMethod<void>('createConversationChannel', {
+      'id': id,
+      'name': name,
+      'groupId': ?groupId,
+      'parentChannelId': parentChannelId,
+      'shortcutId': shortcutId,
+    });
+  }
+
+  static Future<void> removeConversationChannels(List<String> ids) async {
+    if (!PlatformInfos.isAndroid || ids.isEmpty) return;
+    await _channel.invokeMethod<void>('removeConversationChannels', {
+      'ids': ids,
+    });
+  }
+}

--- a/lib/utils/push_helper.dart
+++ b/lib/utils/push_helper.dart
@@ -3,13 +3,13 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import 'dart:convert';
 import 'dart:ui';
 
 import 'package:collection/collection.dart';
 import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/config/setting_keys.dart';
 import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/utils/android_conversation_notifications.dart';
 import 'package:fluffychat/utils/client_download_content_extension.dart';
 import 'package:fluffychat/utils/client_manager.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/matrix_locals.dart';
@@ -19,7 +19,6 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:flutter_new_badger/flutter_new_badger.dart';
-import 'package:flutter_shortcuts_new/flutter_shortcuts_new.dart';
 import 'package:matrix/matrix.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -255,26 +254,26 @@ Future<void> _tryPushHelper(
     notificationGroupId,
     groupName,
   );
-  final roomsChannel = AndroidNotificationChannel(
-    event.room.id,
-    roomName,
-    groupId: notificationGroupId,
-  );
 
   await flutterLocalNotificationsPlugin
       .resolvePlatformSpecificImplementation<
         AndroidFlutterLocalNotificationsPlugin
       >()
       ?.createNotificationChannelGroup(messageRooms);
-  await flutterLocalNotificationsPlugin
-      .resolvePlatformSpecificImplementation<
-        AndroidFlutterLocalNotificationsPlugin
-      >()
-      ?.createNotificationChannel(roomsChannel);
+
+  if (PlatformInfos.isAndroid) {
+    await AndroidConversationNotifications.createConversationChannel(
+      id: event.room.id,
+      name: roomName,
+      groupId: notificationGroupId,
+      parentChannelId: AppConfig.pushNotificationsChannelId,
+      shortcutId: event.room.id,
+    );
+  }
 
   final androidPlatformChannelSpecifics = AndroidNotificationDetails(
-    AppConfig.pushNotificationsChannelId,
-    l10n.incomingMessages,
+    event.room.id,
+    roomName,
     number: notification.counts?.unread,
     category: AndroidNotificationCategory.message,
     shortcutId: event.room.id,
@@ -337,8 +336,14 @@ Future<void> _tryPushHelper(
 
   final title = event.room.getLocalizedDisplayname(MatrixLocals(l10n));
 
-  if (PlatformInfos.isAndroid && messagingStyleInformation == null) {
-    await _setShortcut(event, l10n, title, roomAvatarFile);
+  if (PlatformInfos.isAndroid) {
+    await AndroidConversationNotifications.publishShortcut(
+      id: event.room.id,
+      name: roomName,
+      roomUrl: AppConfig.inviteLinkPrefix + event.room.id,
+      avatar: roomAvatarFile,
+      isImportant: event.room.isFavourite,
+    );
   }
 
   final needsTitleAndBody = !PlatformInfos.isAndroid;
@@ -431,32 +436,6 @@ class FluffyChatPushPayload {
 
   @override
   String toString() => '$clientName|$roomId|$eventId';
-}
-
-/// Creates a shortcut for Android platform but does not block displaying the
-/// notification. This is optional but provides a nicer view of the
-/// notification popup.
-Future<void> _setShortcut(
-  Event event,
-  L10n l10n,
-  String title,
-  Uint8List? avatarFile,
-) async {
-  final flutterShortcuts = FlutterShortcuts();
-  await flutterShortcuts.initialize(debug: !kReleaseMode);
-  await flutterShortcuts.pushShortcutItem(
-    shortcut: ShortcutItem(
-      id: event.room.id,
-      action: AppConfig.inviteLinkPrefix + event.room.id,
-      shortLabel: title,
-      conversationShortcut: true,
-      icon: avatarFile == null ? null : base64Encode(avatarFile),
-      shortcutIconAsset: avatarFile == null
-          ? ShortcutIconAsset.androidAsset
-          : ShortcutIconAsset.memoryAsset,
-      isImportant: event.room.isFavourite,
-    ),
-  );
 }
 
 extension on Client {

--- a/lib/widgets/matrix.dart
+++ b/lib/widgets/matrix.dart
@@ -33,6 +33,7 @@ import 'package:url_launcher/url_launcher_string.dart';
 import '../config/setting_keys.dart';
 import '../pages/key_verification/key_verification_dialog.dart';
 import '../utils/account_bundles.dart';
+import '../utils/android_conversation_notifications.dart';
 import '../utils/background_push.dart';
 import 'local_notifications_extension.dart';
 
@@ -256,6 +257,14 @@ class MatrixState extends State<Matrix> {
         .where((state) => state == LoginState.loggedOut)
         .listen((_) {
           final loggedInWithMultipleClients = widget.clients.length > 1;
+
+          if (PlatformInfos.isAndroid) {
+            final roomIds = c.rooms.map((r) => r.id).toList();
+            AndroidConversationNotifications.removeShortcuts(roomIds).ignore();
+            AndroidConversationNotifications.removeConversationChannels(
+              roomIds,
+            ).ignore();
+          }
 
           _cancelSubs(c.clientName);
           widget.clients.remove(c);


### PR DESCRIPTION
Add SHORTCUT_CATEGORY_CONVERSATION to room shortcuts and link per-room notification channels with setConversationId so MessagingStyle notifications appear in Android's Conversations section. Clean up shortcuts and channels on logout.

- [x] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [x] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/a6c97a35-6251-4552-a83f-903d45cd28cd" />

Fixes: https://github.com/krille-chan/fluffychat/issues/868