### PR TITLE
fix: ImageViewer and MxcImageViewer should not use root navigator

### DIFF
--- a/lib/pages/chat/events/message_content.dart
+++ b/lib/pages/chat/events/message_content.dart
@@ -92,6 +92,7 @@ class MessageContent extends StatelessWidget {
               textColor: textColor,
               onTap: () => showDialog(
                 context: context,
+                useRootNavigator: false,
                 builder: (_) => ImageViewer(
                   event,
                   timeline: timeline,

--- a/lib/pages/chat/events/video_player.dart
+++ b/lib/pages/chat/events/video_player.dart
@@ -70,6 +70,7 @@ class EventVideoPlayer extends StatelessWidget {
             onTap: () => supportsVideoPlayer
                 ? showDialog(
                     context: context,
+                    useRootNavigator: false,
                     builder: (_) => ImageViewer(
                       event,
                       timeline: timeline,

--- a/lib/pages/chat_details/chat_details_view.dart
+++ b/lib/pages/chat_details/chat_details_view.dart
@@ -114,6 +114,7 @@ class ChatDetailsView extends StatelessWidget {
                                       onTap: roomAvatar != null
                                           ? () => showDialog(
                                               context: context,
+                                              useRootNavigator: false,
                                               builder: (_) =>
                                                   MxcImageViewer(roomAvatar),
                                             )

--- a/lib/pages/chat_search/chat_search_images_tab.dart
+++ b/lib/pages/chat_search/chat_search_images_tab.dart
@@ -103,6 +103,7 @@ class ChatSearchImagesTab extends StatelessWidget {
                 return InkWell(
                   onTap: () => showDialog(
                     context: context,
+                    useRootNavigator: false,
                     builder: (_) => ImageViewer(event, outerContext: context),
                   ),
                   borderRadius: borderRadius,

--- a/lib/pages/settings/settings_view.dart
+++ b/lib/pages/settings/settings_view.dart
@@ -65,6 +65,7 @@ class SettingsView extends StatelessWidget {
                             onTap: avatar != null
                                 ? () => showDialog(
                                     context: context,
+                                    useRootNavigator: false,
                                     builder: (_) => MxcImageViewer(avatar),
                                   )
                                 : null,

--- a/lib/widgets/adaptive_dialogs/public_room_dialog.dart
+++ b/lib/widgets/adaptive_dialogs/public_room_dialog.dart
@@ -125,6 +125,7 @@ class PublicRoomDialog extends StatelessWidget {
                         onTap: avatar != null
                             ? () => showDialog(
                                 context: context,
+                                useRootNavigator: false,
                                 builder: (_) => MxcImageViewer(avatar),
                               )
                             : null,

--- a/lib/widgets/adaptive_dialogs/user_dialog.dart
+++ b/lib/widgets/adaptive_dialogs/user_dialog.dart
@@ -83,6 +83,7 @@ class UserDialog extends StatelessWidget {
                     onTap: avatar != null
                         ? () => showDialog(
                             context: context,
+                            useRootNavigator: false,
                             builder: (_) => MxcImageViewer(avatar),
                           )
                         : null,


### PR DESCRIPTION
This resolves https://github.com/krille-chan/fluffychat/issues/2495
`showDialog` uses flutters root navigator which was conflicting with the navigator used by `go_router`. Setting `useRootNavigator` to false puts the dialog on the same navigator which lets the back gesture properly pop it.

I've applied and tested these changes on dialogs that use `ImageViewer` and `MxcImageViewer` as these are the ones the bug is concerned with. There are other instances where `showDialog` is used but I could not produce similar bugs. They don't use the image viewer.

- [x] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [x] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS