### PR TITLE
fix: use application cache directory for files on linux

### DIFF
--- a/lib/utils/matrix_sdk_extensions/flutter_matrix_dart_sdk_database/builder.dart
+++ b/lib/utils/matrix_sdk_extensions/flutter_matrix_dart_sdk_database/builder.dart
@@ -65,7 +65,9 @@ Future<MatrixSdkDatabase> _constructDatabase(String clientName) async {
 
   Directory? fileStorageLocation;
   try {
-    final temporaryDirectory = await getTemporaryDirectory();
+    final temporaryDirectory = PlatformInfos.isLinux
+        ? await getApplicationCacheDirectory()
+        : await getTemporaryDirectory();
     fileStorageLocation = await Directory(
       join(temporaryDirectory.path, 'fluffychat_download_cache'),
     ).create(recursive: true);


### PR DESCRIPTION
Snapcraft or other sandboxed versions may not be able to access the tmp directory.

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS