### PR TITLE
feat: add double-tap to react option in settings

### DIFF
--- a/lib/config/setting_keys.dart
+++ b/lib/config/setting_keys.dart
@@ -75,7 +75,9 @@ enum AppSettings<T> {
   webNotificationSound<bool>('chat.fluffy.web_notification_sound', true),
   chatFilter<String>('chat.fluffy.chat_filter', 'allChats'),
   hideRoomsInSpaces<bool>('chat.fluffy.hideRoomsInSpaces', false),
-  showThumbnailsInTimeline<bool>('chat.fluffy.showThumbnailsInTimeline', true);
+  showThumbnailsInTimeline<bool>('chat.fluffy.showThumbnailsInTimeline', true),
+  doubleTapToReact<bool>('chat.fluffy.double_tap_to_react', false),
+  doubleTapReaction<String>('chat.fluffy.double_tap_reaction', '❤️');
 
   final String key;
   final T defaultValue;

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -2760,5 +2760,8 @@
     "loadingMessages": "Loading messages...",
     "buildDoesNotSupportFirebase": "This build does not support firebase cloud messaging.",
     "unableToRegisterDeviceForFirebase": "Unable to register device for firebase cloud messaging.",
-    "unifiedPushDistributors": "Unified Push distributors:"
+    "unifiedPushDistributors": "Unified Push distributors:",
+    "doubleTapToReact": "Double-tap to react",
+    "doubleTapToReactDescription": "Double-tap a message to react instead of selecting text",
+    "doubleTapReaction": "Double-tap reaction"
 }

--- a/lib/l10n/intl_pl.arb
+++ b/lib/l10n/intl_pl.arb
@@ -2717,5 +2717,8 @@
     },
     "unlockWithBiometrics": "Odblokuj za pomocą uwierzytelniania biometrycznego",
     "useAppLock": "Użyj blokady aplikacji",
-    "biometricsDescription": "Za pomocą biometrycznego uwierzytelniania możesz odblokować aplikację za pomocą swojej twarzy lub odsisku palca. Możliwości zależą od twojego urządzenia."
+    "biometricsDescription": "Za pomocą biometrycznego uwierzytelniania możesz odblokować aplikację za pomocą swojej twarzy lub odsisku palca. Możliwości zależą od twojego urządzenia.",
+    "doubleTapToReact": "Podwójne dotknięcie, aby zareagować",
+    "doubleTapToReactDescription": "Podwójne dotknięcie wiadomości reaguje zamiast zaznaczania tekstu",
+    "doubleTapReaction": "Reakcja podwójnego dotknięcia"
 }

--- a/lib/pages/chat/events/message.dart
+++ b/lib/pages/chat/events/message.dart
@@ -5,6 +5,7 @@
 
 import 'dart:ui' as ui;
 
+import 'package:collection/collection.dart';
 import 'package:emoji_picker_flutter/emoji_picker_flutter.dart';
 import 'package:fluffychat/config/setting_keys.dart';
 import 'package:fluffychat/config/themes.dart';
@@ -385,6 +386,45 @@ class Message extends StatelessWidget {
                               alignment: alignment,
                               padding: const EdgeInsets.only(left: 8),
                               child: GestureDetector(
+                                onDoubleTap:
+                                    AppSettings.doubleTapToReact.value &&
+                                        event.room.canSendDefaultMessages
+                                    ? () {
+                                        HapticFeedback.lightImpact();
+                                        final emoji =
+                                            AppSettings.doubleTapReaction.value;
+                                        final existingReaction = event
+                                            .aggregatedEvents(
+                                              timeline,
+                                              RelationshipTypes.reaction,
+                                            )
+                                            .firstWhereOrNull(
+                                              (e) =>
+                                                  e.senderId ==
+                                                      event
+                                                          .room
+                                                          .client
+                                                          .userID &&
+                                                  e.content
+                                                          .tryGetMap<
+                                                            String,
+                                                            Object?
+                                                          >('m.relates_to')
+                                                          ?.tryGet<String>(
+                                                            'key',
+                                                          ) ==
+                                                      emoji,
+                                            );
+                                        if (existingReaction != null) {
+                                          existingReaction.redactEvent();
+                                        } else {
+                                          event.room.sendReaction(
+                                            event.eventId,
+                                            emoji,
+                                          );
+                                        }
+                                      }
+                                    : null,
                                 onLongPress: longPressSelect
                                     ? null
                                     : () {

--- a/lib/pages/settings_chat/settings_chat.dart
+++ b/lib/pages/settings_chat/settings_chat.dart
@@ -15,6 +15,8 @@ class SettingsChat extends StatefulWidget {
 }
 
 class SettingsChatController extends State<SettingsChat> {
+  void updateState() => setState(() {});
+
   @override
   Widget build(BuildContext context) => SettingsChatView(this);
 }

--- a/lib/pages/settings_chat/settings_chat_view.dart
+++ b/lib/pages/settings_chat/settings_chat_view.dart
@@ -3,9 +3,11 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+import 'package:emoji_picker_flutter/emoji_picker_flutter.dart';
 import 'package:fluffychat/config/setting_keys.dart';
 import 'package:fluffychat/config/themes.dart';
 import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/utils/adaptive_bottom_sheet.dart';
 import 'package:fluffychat/utils/platform_infos.dart';
 import 'package:fluffychat/widgets/layouts/max_width_body.dart';
 import 'package:fluffychat/widgets/matrix.dart';
@@ -69,6 +71,70 @@ class SettingsChatView extends StatelessWidget {
                 title: L10n.of(context).showThumbnailsInTimeline,
                 setting: AppSettings.showThumbnailsInTimeline,
               ),
+              SettingsSwitchListTile.adaptive(
+                title: L10n.of(context).doubleTapToReact,
+                subtitle: L10n.of(context).doubleTapToReactDescription,
+                setting: AppSettings.doubleTapToReact,
+                onChanged: (_) => controller.updateState(),
+              ),
+              if (AppSettings.doubleTapToReact.value)
+                ListTile(
+                  title: Text(L10n.of(context).doubleTapReaction),
+                  trailing: Text(
+                    AppSettings.doubleTapReaction.value,
+                    style: const TextStyle(fontSize: 24),
+                  ),
+                  onTap: () async {
+                    final emoji = await showAdaptiveBottomSheet<String>(
+                      context: context,
+                      builder: (context) => Scaffold(
+                        appBar: AppBar(
+                          title: Text(L10n.of(context).doubleTapReaction),
+                          leading: CloseButton(
+                            onPressed: () => Navigator.of(context).pop(null),
+                          ),
+                        ),
+                        body: SizedBox(
+                          height: double.infinity,
+                          child: EmojiPicker(
+                            onEmojiSelected: (_, emoji) =>
+                                Navigator.of(context).pop(emoji.emoji),
+                            config: Config(
+                              locale: Localizations.localeOf(context),
+                              emojiViewConfig: const EmojiViewConfig(
+                                backgroundColor: Colors.transparent,
+                              ),
+                              bottomActionBarConfig:
+                                  const BottomActionBarConfig(enabled: false),
+                              categoryViewConfig: CategoryViewConfig(
+                                initCategory: Category.SMILEYS,
+                                backspaceColor: theme.colorScheme.primary,
+                                iconColor: theme.colorScheme.primary.withAlpha(
+                                  128,
+                                ),
+                                iconColorSelected: theme.colorScheme.primary,
+                                indicatorColor: theme.colorScheme.primary,
+                                backgroundColor: theme.colorScheme.surface,
+                              ),
+                              skinToneConfig: SkinToneConfig(
+                                dialogBackgroundColor: Color.lerp(
+                                  theme.colorScheme.surface,
+                                  theme.colorScheme.primaryContainer,
+                                  0.75,
+                                )!,
+                                indicatorColor: theme.colorScheme.onSurface,
+                              ),
+                            ),
+                          ),
+                        ),
+                      ),
+                    );
+                    if (emoji != null) {
+                      await AppSettings.doubleTapReaction.setItem(emoji);
+                      controller.updateState();
+                    }
+                  },
+                ),
               Divider(color: theme.dividerColor),
               ListTile(
                 title: Text(


### PR DESCRIPTION
Adds an optional double-tap message reaction feature. This is a familiar gesture from popular messengers like Messenger (which I'm migrating from currently), WhatsApp and Telegram.

- [x] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [x] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [x] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS