### PR TITLE
fix: notification reactions not shown in unifiedpush, fcm worked

### DIFF
--- a/lib/utils/background_push.dart
+++ b/lib/utils/background_push.dart
@@ -433,8 +433,6 @@ class BackgroundPush {
       l10n: l10n,
       activeRoomId: matrix?.activeRoomId,
       flutterLocalNotificationsPlugin: _flutterLocalNotificationsPlugin,
-      useNotificationActions:
-          false, // Buggy with UP: https://codeberg.org/UnifiedPush/flutter-connector/issues/34
     );
   }
 }

--- a/lib/utils/push_helper.dart
+++ b/lib/utils/push_helper.dart
@@ -35,7 +35,6 @@ Future<void> pushHelper(
   L10n? l10n,
   String? activeRoomId,
   required FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin,
-  bool useNotificationActions = true,
 }) async {
   l10n ??= await lookupL10n(PlatformDispatcher.instance.locale);
   final progressNotificationTimer =
@@ -56,7 +55,6 @@ Future<void> pushHelper(
       l10n: l10n,
       activeRoomId: activeRoomId,
       flutterLocalNotificationsPlugin: flutterLocalNotificationsPlugin,
-      useNotificationActions: useNotificationActions,
     );
   } catch (e, s) {
     if (PlatformInfos.isAndroid &&
@@ -110,7 +108,6 @@ Future<void> _tryPushHelper(
   L10n? l10n,
   String? activeRoomId,
   required FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin,
-  bool useNotificationActions = true,
 }) async {
   final isBackgroundMessage = clients == null;
   Logs().v(
@@ -328,7 +325,7 @@ Future<void> _tryPushHelper(
     importance: Importance.high,
     priority: Priority.max,
     groupKey: client.clientName,
-    actions: event.type == EventTypes.RoomMember || !useNotificationActions
+    actions: event.type == EventTypes.RoomMember
         ? null
         : <AndroidNotificationAction>[
             AndroidNotificationAction(


### PR DESCRIPTION
Notification actions (reply, mark as read, mute) were suppressed on the UnifiedPush path as a workaround for [flutter-connector#34](https://codeberg.org/UnifiedPush/flutter-connector/issues/34); that bug was fixed upstream in unifiedpush_android 3.4.1, which pubspec.lock already pins, so the workaround is no longer needed.

Background Info:
This resulted in Android Auto not working with Fluffy since (to my understanding) Android Auto only catches chat messages, which they were not classified as without reactions.

- [x] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [x] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS