### PR TITLE
feat(android): support sharing images, video, audio, and files

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -80,23 +80,25 @@
                <data android:scheme="im.fluffychat" android:host="chat" />
             </intent-filter>
 
-            <!-- App can receive shared text -->
+            <!-- App can receive shared content (text, images, video, audio, files) -->
             <intent-filter>
                <action android:name="android.intent.action.SEND" />
                <category android:name="android.intent.category.DEFAULT" />
-               <data android:mimeType="text/*" />
+               <data android:mimeType="text/plain" />
+               <data android:mimeType="image/*" />
+               <data android:mimeType="video/*" />
+               <data android:mimeType="audio/*" />
+               <data android:mimeType="application/*" />
             </intent-filter>
 
-            <!-- App can receive shared any type of files -->
-            <intent-filter>
-                <action android:name="android.intent.action.SEND" />
-                <category android:name="android.intent.category.DEFAULT" />
-                <data android:mimeType="*/*" />
-            </intent-filter>
+            <!-- App can receive multiple files -->
             <intent-filter>
                 <action android:name="android.intent.action.SEND_MULTIPLE" />
                 <category android:name="android.intent.category.DEFAULT" />
-                <data android:mimeType="*/*" />
+                <data android:mimeType="image/*" />
+                <data android:mimeType="video/*" />
+                <data android:mimeType="audio/*" />
+                <data android:mimeType="application/*" />
             </intent-filter>
         </activity>
 

--- a/android/app/src/main/kotlin/chat/fluffy/fluffychat/MainActivity.kt
+++ b/android/app/src/main/kotlin/chat/fluffy/fluffychat/MainActivity.kt
@@ -2,8 +2,13 @@ package chat.fluffy.fluffychat
 
 import io.flutter.embedding.android.FlutterFragmentActivity
 import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.MethodChannel
 
 import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import java.io.File
+import java.io.FileOutputStream
 
 class MainActivity : FlutterFragmentActivity() {
 
@@ -11,13 +16,32 @@ class MainActivity : FlutterFragmentActivity() {
         super.attachBaseContext(base)
     }
 
-
     override fun provideFlutterEngine(context: Context): FlutterEngine? {
         return provideEngine(this)
     }
 
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
         // do nothing, because the engine was been configured in provideEngine
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+
+        // Copy camera/gallery shared file to local cache before permission is lost
+        if (intent.action == Intent.ACTION_SEND && intent.type?.startsWith("image/") == true) {
+            val uri = intent.getParcelableExtra<Uri>(Intent.EXTRA_STREAM) ?: return
+            try {
+                val input = contentResolver.openInputStream(uri) ?: return
+                val file = File(cacheDir, "shared_${System.currentTimeMillis()}.jpg")
+                FileOutputStream(file).use { fos -> input.copyTo(fos) }
+                input.close()
+                val channel = MethodChannel(
+                    provideEngine(this).dartExecutor.binaryMessenger, "fluffychat/share"
+                )
+                channel.invokeMethod("share_image", file.absolutePath)
+            } catch (_: Exception) {}
+        }
     }
 
     companion object {


### PR DESCRIPTION
- Updated AndroidManifest to replace generic text/* and */* MIME filters with specific types (image, video, audio, application) for both single and multiple share intents.
- Added onNewIntent override in MainActivity to handle incoming image shares: copies shared image to app cache before URI permission is lost, then invokes a MethodChannel (`fluffychat/share`) with the file path.
- Removed general */* intent filter to avoid unintended handling of non-media types while keeping support for text/plain.

- [*] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [*] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS