### PR TITLE
fix: Correct German translation for markAsRead

### DIFF
--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -1743,7 +1743,7 @@
             }
         }
     },
-    "markAsRead": "Als gelesen markiert",
+    "markAsRead": "Als gelesen markieren",
     "reportUser": "Benutzer melden",
     "confirmEventUnpin": "Möchtest du das Ereignis wirklich dauerhaft lösen?",
     "youKicked": "👞 Du hast {user} rausgeworfen",


### PR DESCRIPTION
- [X ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

This is just a small translation fix. the "markAsRead" string appears in a notification for a new message, where one can directly mark said message as read. This clearly should be translated as "Als gelesen markieren", not "Als gelesen markiert".