### PR TITLE
fix: remove extra spacing in sticker selection dialog

### DIFF
--- a/lib/pages/chat/sticker_picker_dialog.dart
+++ b/lib/pages/chat/sticker_picker_dialog.dart
@@ -39,10 +39,12 @@ class StickerPickerDialogState extends State<StickerPickerDialog> {
     return Material(
       color: theme.colorScheme.onInverseSurface,
       child: SafeArea(
+        top: false,
         child: CustomScrollView(
           slivers: <Widget>[
             SliverAppBar(
               floating: true,
+              primary: false,
               toolbarHeight: 72,
               scrolledUnderElevation: 0,
               backgroundColor: Colors.transparent,
@@ -129,6 +131,7 @@ class StickerPickerDialogState extends State<StickerPickerDialog> {
                         ),
                       const SizedBox(height: 6),
                       GridView.builder(
+                        padding: EdgeInsets.zero,
                         itemCount: imageKeys.length,
                         gridDelegate:
                             const SliverGridDelegateWithMaxCrossAxisExtent(


### PR DESCRIPTION
Fixes an issue I started to see recently where there's some extra spacing in the sticker selection dialog, which was also reported in #3181. See below for comparison on Android/Desktop Linux:

|Before| After|
|---|---|
| <img width="1080" height="1392" alt="Screenshot_1785633195" src="https://github.com/user-attachments/assets/6ccc195c-7f1f-4d4d-89ac-d1425067bf37" /> | <img width="1080" height="1392" alt="Screenshot_1785633206" src="https://github.com/user-attachments/assets/fb1710aa-3084-46aa-94a6-8ff3a57f10df" /> |
| <img width="773" height="567" alt="image" src="https://github.com/user-attachments/assets/98120bc8-26b5-4587-aa6c-c69f319959d8" /> | <img width="773" height="567" alt="image" src="https://github.com/user-attachments/assets/47d47cce-1e17-40fb-b5eb-cc65e3661aa5" /> |

- [x] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [x] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [x] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS