### PR TITLE
fix: display UnifiedPush multiple provider modal

### DIFF
--- a/lib/pages/chat_list/chat_list.dart
+++ b/lib/pages/chat_list/chat_list.dart
@@ -80,6 +80,7 @@ class ChatListController extends State<ChatList>
   String? activeTag;
 
   String? _activeSpaceId;
+
   String? get activeSpaceId => _activeSpaceId;
 
   Future<void> setActiveSpace(String spaceId) async {
@@ -386,7 +387,7 @@ class ChatListController extends State<ChatList>
         searchServer = Matrix.of(
           context,
         ).store.getString(_serverStoreNamespace);
-        Matrix.of(context).backgroundPush?.setupPush();
+        Matrix.of(context).backgroundPush?.setupPush(context);
         UpdateNotifier.showUpdateDialog(context);
       }
 

--- a/lib/utils/background_push.dart
+++ b/lib/utils/background_push.dart
@@ -35,10 +35,12 @@ class BackgroundPush {
       FlutterLocalNotificationsPlugin();
 
   List<Client> _clients;
+
   List<Client> get clients => matrix?.widget.clients ?? _clients;
 
   MatrixState? matrix;
   String? _fcmToken;
+
   String? get fcmToken => _fcmToken;
   void Function(String errorMsg, {Uri? link})? onFcmError;
   L10n? l10n;
@@ -261,11 +263,9 @@ class BackgroundPush {
 
   static bool _wentToRoomOnStartup = false;
 
-  Future<void> setupPush() async {
-    final context = matrix?.context;
+  Future<void> setupPush(BuildContext context) async {
     if (PlatformInfos.isAndroid &&
         (await UnifiedPush.getDistributors()).isNotEmpty &&
-        context != null &&
         context.mounted) {
       await UnifiedPushUi(
         context: context,


### PR DESCRIPTION
Fix #3231 | Fix #3212  | Fix #2250 

The context used when creating Matrix widget does not contain a Navigator leading to a crash of Unified Push multiple provider modal. In order to fix it, I pass the context from `chat_list` as a parameter (which is build as child of a Navigator)

I've tried with an emulated medium phone with Ntfy and Sunup installed.
- Choosing one of the provider effectively registers it
- Choosing no provider does nothing (and the user is faced again with the modal when the app starts again)

- [X] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [X] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS