### PR TITLE
Trust user installed CA certificates on Android

### DIFF
--- a/android/app/src/main/kotlin/chat/fluffy/fluffychat/MainActivity.kt
+++ b/android/app/src/main/kotlin/chat/fluffy/fluffychat/MainActivity.kt
@@ -24,6 +24,7 @@ class MainActivity : FlutterFragmentActivity() {
         var engine: FlutterEngine? = null
         fun provideEngine(context: Context): FlutterEngine {
             val eng = engine ?: FlutterEngine(context, emptyArray(), true, false)
+            UserCaLoader(eng.dartExecutor.binaryMessenger)
             engine = eng
             return eng
         }

--- a/android/app/src/main/kotlin/chat/fluffy/fluffychat/UserCaLoader.kt
+++ b/android/app/src/main/kotlin/chat/fluffy/fluffychat/UserCaLoader.kt
@@ -1,0 +1,45 @@
+package chat.fluffy.fluffychat
+
+import io.flutter.plugin.common.BinaryMessenger
+import io.flutter.plugin.common.MethodChannel
+import java.security.KeyStore
+import java.security.cert.X509Certificate
+
+const val USER_CA_CHANNEL = "chat.fluffy.fluffychat/user_ca"
+
+class UserCaLoader(
+    private val binaryMessenger: BinaryMessenger,
+) {
+    private val methodChannel = MethodChannel(binaryMessenger, USER_CA_CHANNEL)
+
+    init {
+        methodChannel.setMethodCallHandler { call, result ->
+            when (call.method) {
+                "getUserCertificates" -> loadUserCerts(result)
+                else -> result.notImplemented()
+            }
+        }
+    }
+
+    fun dispose() {
+        methodChannel.setMethodCallHandler(null)
+    }
+
+    private fun loadUserCerts(result: MethodChannel.Result) {
+        val certificates = try {
+            val keyStore = KeyStore.getInstance("AndroidCAStore")
+            keyStore.load(null, null)
+            // The plugin name uses "user" prefix for user-installed CA certs
+            val aliasList = keyStore.aliases().toList()
+                .filter { it.startsWith("user") }
+            val mapOfBytes = aliasList.associate {
+                val cert = keyStore.getCertificate(it) as X509Certificate
+                it to cert.encoded
+            }
+            mapOfBytes
+        } catch (e: Exception) {
+            emptyMap<String, ByteArray>()
+        }
+        result.success(certificates)
+    }
+}

--- a/lib/utils/client_manager.dart
+++ b/lib/utils/client_manager.dart
@@ -115,7 +115,7 @@ abstract class ClientManager {
 
     return Client(
       clientName,
-      httpClient: CustomHttpClient.createHTTPClient(),
+      httpClient: await CustomHttpClient.createHTTPClient(),
       verificationMethods: {
         KeyVerificationMethod.numbers,
         if (kIsWeb || PlatformInfos.isMobile || PlatformInfos.isLinux)

--- a/lib/utils/custom_http_client.dart
+++ b/lib/utils/custom_http_client.dart
@@ -9,6 +9,7 @@ import 'dart:io';
 import 'package:fluffychat/config/isrg_x1.dart';
 import 'package:fluffychat/config/isrg_x2.dart';
 import 'package:fluffychat/utils/platform_infos.dart';
+import 'package:flutter_user_certificates_android/flutter_user_certificates_android.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/io_client.dart';
 import 'package:http/retry.dart' as retry;
@@ -17,25 +18,52 @@ import 'package:http/retry.dart' as retry;
 /// Encrypt. Older Android versions may not include these roots in their
 /// trust store, so we ship them ourselves to ensure TLS connections to
 /// Let's Encrypt–signed servers continue to work.
+///
+/// On Android, user-installed CA certificates are also added, since apps
+/// targeting API 24+ do not trust them by default.
 class CustomHttpClient {
-  static HttpClient customHttpClient() {
-    final context = SecurityContext.defaultContext;
+  static String derToPem(List<int> der) =>
+      '-----BEGIN CERTIFICATE-----\n${base64Encode(der)}\n-----END CERTIFICATE-----';
 
-    try {
-      context.setTrustedCertificatesBytes(utf8.encode(ISRG_X1));
-      context.setTrustedCertificatesBytes(utf8.encode(ISRG_X2));
-    } on TlsException catch (e) {
-      if (e.osError != null &&
-          e.osError!.message.contains('CERT_ALREADY_IN_HASH_TABLE')) {
-      } else {
-        rethrow;
+  static Future<SecurityContext> buildSecurityContext() async {
+    final context = SecurityContext(withTrustedRoots: true);
+    _addTrustedCertificates(context, [ISRG_X1, ISRG_X2]);
+
+    if (PlatformInfos.isAndroid) {
+      final userCerts =
+          await FlutterUserCertificatesAndroid().getUserCertificates();
+
+      if (userCerts != null && userCerts.isNotEmpty) {
+        final pem = userCerts.values.map(derToPem).join('\n');
+        _addTrustedCertificates(context, [pem]);
       }
     }
 
-    return HttpClient(context: context);
+    return context;
   }
 
-  static http.Client createHTTPClient() => retry.RetryClient(
-    PlatformInfos.isAndroid ? IOClient(customHttpClient()) : http.Client(),
+  static void _addTrustedCertificates(
+    SecurityContext context,
+    Iterable<String> certificates,
+  ) {
+    for (final certificate in certificates) {
+      try {
+        context.setTrustedCertificatesBytes(utf8.encode(certificate));
+      } on TlsException catch (e) {
+        if (e.osError != null &&
+            e.osError!.message.contains('CERT_ALREADY_IN_HASH_TABLE')) {
+          // The certificate is already present; nothing to do.
+        } else {
+          rethrow;
+        }
+      }
+    }
+  }
+
+  static Future<HttpClient> customHttpClient() async =>
+      HttpClient(context: await buildSecurityContext());
+
+  static Future<http.Client> createHTTPClient() async => retry.RetryClient(
+    PlatformInfos.isAndroid ? IOClient(await customHttpClient()) : http.Client(),
   );
 }

--- a/lib/utils/custom_http_client.dart
+++ b/lib/utils/custom_http_client.dart
@@ -6,13 +6,17 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 import 'package:fluffychat/config/isrg_x1.dart';
 import 'package:fluffychat/config/isrg_x2.dart';
 import 'package:fluffychat/utils/platform_infos.dart';
-import 'package:flutter_user_certificates_android/flutter_user_certificates_android.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/io_client.dart';
 import 'package:http/retry.dart' as retry;
+
+/// Method channel used to load user-installed CA certificates on Android.
+const _userCaChannel = MethodChannel('chat.fluffy.fluffychat/user_ca');
 
 /// Custom HTTP client that adds the ISRG Root certificates used by Let's
 /// Encrypt. Older Android versions may not include these roots in their
@@ -30,12 +34,21 @@ class CustomHttpClient {
     _addTrustedCertificates(context, [ISRG_X1, ISRG_X2]);
 
     if (PlatformInfos.isAndroid) {
-      final userCerts =
-          await FlutterUserCertificatesAndroid().getUserCertificates();
+      try {
+        final userCertsRaw =
+            await _userCaChannel.invokeMethod<Map>('getUserCertificates');
 
-      if (userCerts != null && userCerts.isNotEmpty) {
-        final pem = userCerts.values.map(derToPem).join('\n');
-        _addTrustedCertificates(context, [pem]);
+        if (userCertsRaw != null && userCertsRaw.isNotEmpty) {
+          // Convert the Map<String, Uint8List> to List<int> PEM strings
+          final pem = userCertsRaw.values.map(
+            (bytes) => derToPem((bytes as List<int>).toList()),
+          ).join('\n');
+          _addTrustedCertificates(context, [pem]);
+        }
+      } on PlatformException catch (e) {
+        // If the method channel isn't available (shouldn't happen on Android),
+        // log but continue without user certs
+        debugPrint('Failed to load user CA certificates: ${e.message}');
       }
     }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,6 +42,7 @@ dependencies:
   flutter_new_badger: ^2.0.0
   flutter_secure_storage: ^11.0.0
   flutter_shortcuts_new: ^2.0.0
+  flutter_user_certificates_android: ^0.1.0
   flutter_vodozemac: ^0.8.1
   flutter_web_auth_2: ^5.1.0
   flutter_webrtc: ^1.6.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,7 +42,6 @@ dependencies:
   flutter_new_badger: ^2.0.0
   flutter_secure_storage: ^11.0.0
   flutter_shortcuts_new: ^2.0.0
-  flutter_user_certificates_android: ^0.1.0
   flutter_vodozemac: ^0.8.1
   flutter_web_auth_2: ^5.1.0
   flutter_webrtc: ^1.6.0


### PR DESCRIPTION
- [x] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [x] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

This pull request adds the user certificates to the trusted CAs to the custom http client.
Fixes https://github.com/krille-chan/fluffychat/issues/1393