### PR TITLE
fix: remove extra spacing in autocomplete popover

### DIFF
--- a/lib/pages/chat/input_bar.dart
+++ b/lib/pages/chat/input_bar.dart
@@ -456,6 +456,7 @@ class InputBar extends StatelessWidget {
           borderRadius: BorderRadius.circular(AppConfig.borderRadius),
           clipBehavior: Clip.hardEdge,
           child: ListView.builder(
+            padding: EdgeInsets.zero,
             shrinkWrap: true,
             itemCount: suggestions.length,
             itemBuilder: (context, i) => buildSuggestion(


### PR DESCRIPTION
- Similar to previous fix, this one is for removing the extra spacing at the top of the autocomplete popover that displays for room commands and custom emotes
- The issue was visible on Android and iOS but not Linux
- Fix works for Android and has no effect on existing Linux UI
- Comparison below (popover is red for clarity)

|Before| After|
|---|---|
| <img width="1080" height="2400" alt="Screenshot_1787283665" src="https://github.com/user-attachments/assets/dbba8505-091c-4a9f-b34b-1f4ae8fe0c7c" /> | <img width="1080" height="2400" alt="Screenshot_1787283771" src="https://github.com/user-attachments/assets/04303d5c-8e57-4a02-85e4-57e3b885ef2f" /> |

- [x] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [x] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [x] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS