### PR TITLE
feat(stickers): add recent stickers

### DIFF
--- a/lib/pages/chat/chat_emoji_picker.dart
+++ b/lib/pages/chat/chat_emoji_picker.dart
@@ -8,6 +8,8 @@ import 'package:fluffychat/config/themes.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pages/chat/sticker_picker_dialog.dart';
 import 'package:fluffychat/pages/chat/trust_user_key_dialog.dart';
+import 'package:fluffychat/utils/recent_stickers_store.dart';
+import 'package:fluffychat/widgets/matrix.dart';
 import 'package:material_ui/material_ui.dart';
 import 'package:matrix/matrix.dart';
 
@@ -77,6 +79,8 @@ class ChatEmojiPicker extends StatelessWidget {
                         StickerPickerDialog(
                           room: controller.room,
                           onSelected: (sticker) async {
+                            final store = Matrix.of(context).store;
+                            final userId = controller.room.client.userID;
                             final proceed = await showTrustUserInRoomDialog(
                               context,
                               controller.room,
@@ -91,6 +95,11 @@ class ChatEmojiPicker extends StatelessWidget {
                               type: EventTypes.Sticker,
                               threadRootEventId: controller.activeThreadId,
                               threadLastEventId: controller.threadLastEventId,
+                            );
+                            await RecentStickersStore.add(
+                              store,
+                              userId,
+                              sticker.url,
                             );
                             controller.hideEmojiPicker();
                           },

--- a/lib/pages/chat/sticker_picker_dialog.dart
+++ b/lib/pages/chat/sticker_picker_dialog.dart
@@ -5,7 +5,9 @@
 
 import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/utils/recent_stickers_store.dart';
 import 'package:fluffychat/utils/url_launcher.dart';
+import 'package:fluffychat/widgets/matrix.dart';
 import 'package:fluffychat/widgets/mxc_image.dart';
 import 'package:material_ui/material_ui.dart';
 import 'package:matrix/matrix.dart';
@@ -29,12 +31,37 @@ class StickerPickerDialog extends StatefulWidget {
 class StickerPickerDialogState extends State<StickerPickerDialog> {
   String? searchFilter;
 
+  void _selectSticker(ImagePackImageContent image, String fallbackBody) {
+    final imageCopy = ImagePackImageContent.fromJson(image.toJson().copy());
+    imageCopy.body ??= fallbackBody;
+    widget.onSelected(imageCopy);
+  }
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
 
     final stickerPacks = widget.room.getImagePacks(ImagePackUsage.sticker);
     final packSlugs = stickerPacks.keys.toList();
+    final currentStickersByUrl = <String, _StickerEntry>{};
+
+    for (final pack in stickerPacks.values) {
+      for (final entry in pack.images.entries) {
+        currentStickersByUrl.putIfAbsent(
+          entry.value.url.toString(),
+          () => _StickerEntry(key: entry.key, image: entry.value),
+        );
+      }
+    }
+
+    final recentStickers =
+        RecentStickersStore.read(
+              Matrix.of(context).store,
+              widget.room.client.userID,
+            )
+            .map((url) => currentStickersByUrl[url])
+            .whereType<_StickerEntry>()
+            .toList(growable: false);
 
     return Material(
       color: theme.colorScheme.onInverseSurface,
@@ -42,6 +69,51 @@ class StickerPickerDialogState extends State<StickerPickerDialog> {
         top: false,
         child: CustomScrollView(
           slivers: <Widget>[
+            if (recentStickers.isNotEmpty)
+              SliverToBoxAdapter(
+                child: SizedBox(
+                  height: 88,
+                  child: ListView.separated(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 12,
+                      vertical: 8,
+                    ),
+                    scrollDirection: Axis.horizontal,
+                    itemCount: recentStickers.length,
+                    separatorBuilder: (context, index) =>
+                        const SizedBox(width: 8),
+                    itemBuilder: (context, index) {
+                      final recentSticker = recentStickers[index];
+                      return SizedBox(
+                        width: 72,
+                        child: Tooltip(
+                          message:
+                              recentSticker.image.body ?? recentSticker.key,
+                          child: InkWell(
+                            radius: AppConfig.borderRadius,
+                            key: ValueKey('recent_${recentSticker.image.url}'),
+                            onTap: () => _selectSticker(
+                              recentSticker.image,
+                              recentSticker.key,
+                            ),
+                            child: AbsorbPointer(
+                              absorbing: true,
+                              child: MxcImage(
+                                uri: recentSticker.image.url,
+                                fit: BoxFit.contain,
+                                width: 72,
+                                height: 72,
+                                animated: true,
+                                isThumbnail: false,
+                              ),
+                            ),
+                          ),
+                        ),
+                      );
+                    },
+                  ),
+                ),
+              ),
             SliverAppBar(
               floating: true,
               primary: false,
@@ -148,16 +220,8 @@ class StickerPickerDialogState extends State<StickerPickerDialog> {
                             child: InkWell(
                               radius: AppConfig.borderRadius,
                               key: ValueKey(image.url.toString()),
-                              onTap: () {
-                                // copy the image
-                                final imageCopy =
-                                    ImagePackImageContent.fromJson(
-                                      image.toJson().copy(),
-                                    );
-                                // set the body, if it doesn't exist, to the key
-                                imageCopy.body ??= imageKeys[imageIndex];
-                                widget.onSelected(imageCopy);
-                              },
+                              onTap: () =>
+                                  _selectSticker(image, imageKeys[imageIndex]),
                               child: AbsorbPointer(
                                 absorbing: true,
                                 child: MxcImage(
@@ -182,4 +246,11 @@ class StickerPickerDialogState extends State<StickerPickerDialog> {
       ),
     );
   }
+}
+
+class _StickerEntry {
+  final String key;
+  final ImagePackImageContent image;
+
+  const _StickerEntry({required this.key, required this.image});
 }

--- a/lib/utils/recent_stickers_store.dart
+++ b/lib/utils/recent_stickers_store.dart
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: 2019-Present Christian Kußowski
+// SPDX-FileCopyrightText: 2019-Present Contributors to FluffyChat
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import 'package:matrix/matrix.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class RecentStickersStore {
+  static const _maxItems = 30;
+  static const _keyPrefix = 'chat.fluffy.recent_stickers.';
+
+  static List<String> read(SharedPreferences store, String? userId) {
+    final key = _keyForUser(userId);
+    if (key == null) return const [];
+
+    try {
+      return _normalize(store.getStringList(key) ?? const []);
+    } catch (error, stackTrace) {
+      Logs().w(
+        'Unable to read recent stickers from local storage',
+        error,
+        stackTrace,
+      );
+      return const [];
+    }
+  }
+
+  static Future<void> add(
+    SharedPreferences store,
+    String? userId,
+    Uri stickerUrl,
+  ) async {
+    final key = _keyForUser(userId);
+    final stickerUrlString = stickerUrl.toString();
+    if (key == null || !_isMxc(stickerUrlString)) return;
+
+    try {
+      final updated = read(
+        store,
+        userId,
+      ).where((item) => item != stickerUrlString).toList();
+      updated.insert(0, stickerUrlString);
+      await store.setStringList(
+        key,
+        updated.take(_maxItems).toList(growable: false),
+      );
+    } catch (error, stackTrace) {
+      Logs().w('Unable to persist recent sticker', error, stackTrace);
+    }
+  }
+
+  static String? _keyForUser(String? userId) {
+    if (userId == null || userId.isEmpty) return null;
+    return '$_keyPrefix$userId';
+  }
+
+  static List<String> _normalize(Iterable<String> stored) {
+    final normalized = <String>[];
+    final seen = <String>{};
+
+    for (final item in stored) {
+      if (!_isMxc(item) || !seen.add(item)) continue;
+      normalized.add(item);
+      if (normalized.length == _maxItems) break;
+    }
+
+    return normalized;
+  }
+
+  static bool _isMxc(String value) {
+    final uri = Uri.tryParse(value);
+    return uri != null &&
+        uri.scheme == 'mxc' &&
+        uri.host.isNotEmpty &&
+        uri.pathSegments.isNotEmpty;
+  }
+}

--- a/test/utils/recent_stickers_store_test.dart
+++ b/test/utils/recent_stickers_store_test.dart
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: 2019-Present Christian Kußowski
+// SPDX-FileCopyrightText: 2019-Present Contributors to FluffyChat
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import 'package:fluffychat/utils/recent_stickers_store.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  late SharedPreferences store;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    store = await SharedPreferences.getInstance();
+  });
+
+  test('stores recent stickers in MRU order without duplicates', () async {
+    const userId = '@alice:example.org';
+    final first = Uri.parse('mxc://example.org/first');
+    final second = Uri.parse('mxc://example.org/second');
+
+    await RecentStickersStore.add(store, userId, first);
+    await RecentStickersStore.add(store, userId, second);
+    await RecentStickersStore.add(store, userId, first);
+
+    expect(RecentStickersStore.read(store, userId), [
+      first.toString(),
+      second.toString(),
+    ]);
+  });
+
+  test('keeps recent stickers separate per Matrix user', () async {
+    final aliceSticker = Uri.parse('mxc://example.org/alice');
+    final bobSticker = Uri.parse('mxc://example.org/bob');
+
+    await RecentStickersStore.add(store, '@alice:example.org', aliceSticker);
+    await RecentStickersStore.add(store, '@bob:example.org', bobSticker);
+
+    expect(RecentStickersStore.read(store, '@alice:example.org'), [
+      aliceSticker.toString(),
+    ]);
+    expect(RecentStickersStore.read(store, '@bob:example.org'), [
+      bobSticker.toString(),
+    ]);
+  });
+
+  test('ignores invalid sticker URLs and missing users', () async {
+    await RecentStickersStore.add(
+      store,
+      '@alice:example.org',
+      Uri.parse('https://example.org/not-mxc'),
+    );
+    await RecentStickersStore.add(
+      store,
+      null,
+      Uri.parse('mxc://example.org/ignored'),
+    );
+
+    expect(RecentStickersStore.read(store, '@alice:example.org'), isEmpty);
+    expect(RecentStickersStore.read(store, null), isEmpty);
+  });
+
+  test('normalizes invalid and duplicate persisted entries', () async {
+    const userId = '@alice:example.org';
+    final first = Uri.parse('mxc://example.org/first');
+    final second = Uri.parse('mxc://example.org/second');
+
+    await RecentStickersStore.add(store, userId, first);
+    final storageKey = store.getKeys().single;
+    await store.setStringList(storageKey, [
+      first.toString(),
+      'https://example.org/not-mxc',
+      first.toString(),
+      second.toString(),
+    ]);
+
+    expect(RecentStickersStore.read(store, userId), [
+      first.toString(),
+      second.toString(),
+    ]);
+  });
+
+  test('keeps only the 30 most recent stickers', () async {
+    const userId = '@alice:example.org';
+
+    for (var index = 0; index < 31; index++) {
+      await RecentStickersStore.add(
+        store,
+        userId,
+        Uri.parse('mxc://example.org/sticker-$index'),
+      );
+    }
+
+    final recent = RecentStickersStore.read(store, userId);
+    expect(recent, hasLength(30));
+    expect(recent.first, 'mxc://example.org/sticker-30');
+    expect(recent.last, 'mxc://example.org/sticker-1');
+  });
+}


### PR DESCRIPTION
New "recents" section above the search bar. If there are no valid recent items, the section does not appear and leaves no empty space. Local per-user history; the most recently used sticker moves to the first position without duplication. Only stickers still present in the packs are shown. Implements only the "recent stickers" part of #3163.

- [x] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [x] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS