### PR TITLE
Fix a bunch of cases where the read marker wasn't being updated

### DIFF
--- a/lib/pages/chat/chat.dart
+++ b/lib/pages/chat/chat.dart
@@ -596,11 +596,12 @@ class ChatController extends State<ChatPageWithRoom>
     // We are already setting a read marker
     if (_setReadMarkerFuture != null) return;
 
-    // We only set read marker if we are at the bottom
-    if (_scrolledUp) return;
-
-    // We do not set read marker if we offer user the scroll up banner
-    if (scrollUpBannerEventId != null) return;
+    // We only set read marker if we are at the bottom. Check the live scroll
+    // position, not the cached _scrolledUp flag, which can be stuck when no
+    // scroll transition ever fired.
+    if (scrollController.hasClients && scrollController.position.pixels > 0) {
+      return;
+    }
 
     // We do not set read marker if timeline is empty
     final timeline = this.timeline;
@@ -614,16 +615,18 @@ class ChatController extends State<ChatPageWithRoom>
     }
 
     final setOnLatestEvent = eventId == null;
+    // Target the latest message-like event. Do not gate this on push rule
+    // evaluation: read markers track what the user has seen, not what
+    // notifies them.
     eventId ??= timeline.events
         .firstWhereOrNull(
-          (event) => room.pushRuleState == PushRuleState.notify
-              ? room.client.pushruleEvaluator.match(event).notify
-              : {
-                      EventTypes.Message,
-                      EventTypes.Encrypted,
-                      EventTypes.Sticker,
-                    }.contains(event.type) &&
-                    event.eventId.isValidMatrixIdStrict(),
+          (event) =>
+              {
+                EventTypes.Message,
+                EventTypes.Encrypted,
+                EventTypes.Sticker,
+              }.contains(event.type) &&
+              event.eventId.isValidMatrixIdStrict(),
         )
         ?.eventId;
 
@@ -638,11 +641,12 @@ class ChatController extends State<ChatPageWithRoom>
     // unread indicator depends on.
     if (room.fullyRead == eventId && !room.hasNewMessages) return;
 
-    // Set a readmarker on a specific event, not latest, but room is not unread
-    // at all.
+    // Room shows nothing new, but the read marker still lags behind this
+    // event (e.g. receipts were posted by another device): advance it.
     if (setOnLatestEvent &&
         !room.hasNewMessages &&
-        room.notificationCount == 0) {
+        room.notificationCount == 0 &&
+        room.fullyRead == eventId) {
       return;
     }
 
@@ -653,7 +657,11 @@ class ChatController extends State<ChatPageWithRoom>
           eventId: eventId,
           public: AppSettings.sendPublicReadReceipts.value,
         )
-        .then((_) {
+        .catchError((Object e, StackTrace s) {
+          Logs().w('Failed to set read marker', e, s);
+        })
+        .whenComplete(() {
+          // Always release the latch, even when the request fails.
           _setReadMarkerFuture = null;
         });
   }

--- a/lib/pages/chat/chat.dart
+++ b/lib/pages/chat/chat.dart
@@ -633,8 +633,10 @@ class ChatController extends State<ChatPageWithRoom>
     // This is a sending event, we do not set a readmarker yet
     if (eventId.isValidMatrixIdStrict() == false) return;
 
-    // Already set a read marker on this event
-    if (room.fullyRead == eventId) return;
+    // Already set a read marker on this event, unless the room still shows
+    // new messages: re-posting refreshes the receipts' timestamps, which the
+    // unread indicator depends on.
+    if (room.fullyRead == eventId && !room.hasNewMessages) return;
 
     // Set a readmarker on a specific event, not latest, but room is not unread
     // at all.

--- a/lib/pages/chat/chat.dart
+++ b/lib/pages/chat/chat.dart
@@ -596,12 +596,17 @@ class ChatController extends State<ChatPageWithRoom>
     // We are already setting a read marker
     if (_setReadMarkerFuture != null) return;
 
-    // We only set read marker if we are at the bottom. Check the live scroll
-    // position, not the cached _scrolledUp flag, which can be stuck when no
-    // scroll transition ever fired.
-    if (scrollController.hasClients && scrollController.position.pixels > 0) {
+    // We only set read marker if we are at the bottom. Prefer the live
+    // scroll position, but fall back to the cached flag when no client is
+    // attached yet.
+    if (scrollController.hasClients
+        ? scrollController.position.pixels > 0
+        : _scrolledUp) {
       return;
     }
+
+    // We do not set read marker if we offer user the scroll up banner
+    if (scrollUpBannerEventId != null) return;
 
     // We do not set read marker if timeline is empty
     final timeline = this.timeline;
@@ -615,6 +620,9 @@ class ChatController extends State<ChatPageWithRoom>
     }
 
     final setOnLatestEvent = eventId == null;
+    // When we are viewing a context slice of older events, do not treat
+    // the newest loaded event as the room's latest event.
+    if (setOnLatestEvent && timeline.allowNewEvent == false) return;
     // Target the latest message-like event. Do not gate this on push rule
     // evaluation: read markers track what the user has seen, not what
     // notifies them.
@@ -641,12 +649,11 @@ class ChatController extends State<ChatPageWithRoom>
     // unread indicator depends on.
     if (room.fullyRead == eventId && !room.hasNewMessages) return;
 
-    // Room shows nothing new, but the read marker still lags behind this
-    // event (e.g. receipts were posted by another device): advance it.
+    // Set a readmarker on a specific event, not latest, but room is not unread
+    // at all.
     if (setOnLatestEvent &&
         !room.hasNewMessages &&
-        room.notificationCount == 0 &&
-        room.fullyRead == eventId) {
+        room.notificationCount == 0) {
       return;
     }
 


### PR DESCRIPTION
These cases would cause the dark blue dot to remain on a room (non-notifying events):

- Push-rule-gated rooms: Read markers are no longer blocked when a room’s push rules match nothing (e.g. channels set to mentions-only). The marker targets the latest real message-like event instead.
- Stuck unread indicator: If room.hasNewMessages is still true despite room.fullyRead already pointing at the latest event, the marker is re-posted to refresh receipt timestamps and clear the channel unread state. Note that this only happens if you are using another client such as Cinny that posts `m.read` or `m.private_read` but not `m.fully_read`.
- Failed marker requests no longer wedge the room: _setReadMarkerFuture is released in whenComplete() even when the request fails.
- Detached views not treated as at-bottom: When no scroll client is attached, the function falls back to the cached _scrolledUp flag instead of assuming the user is at the latest message.
- Context slices protected: When viewing a sliced timeline (timeline.allowNewEvent == false), the newest loaded event is not treated as the room’s latest and the marker is not auto-advanced.

Tested by doing all the stuff CI does locally on my machine and by running an APK build on my phone. My homeserver/account are highly prone to this issue and I had several stuck rooms previously.

This interacts with a couple of Tuwunel bugs that I have also put up PRs for: https://github.com/matrix-construct/tuwunel/pull/564 and https://github.com/matrix-construct/tuwunel/pull/565 . Also now https://github.com/matrix-construct/tuwunel/pull/566 which only impacts rooms with only backfilled events (like when the user is the first joiner from the local homeserver).

I am happy to split out the Cinny interaction fix into a separate PR if you like; that's the most impactful one for people who use multiple clients.

- [X] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [X] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS