### PR TITLE
fix: localize 'Accounts and settings' tooltip in ClientChooserButton

### DIFF
--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -92,6 +92,11 @@
         "type": "String",
         "placeholders": {}
     },
+    "accountsAndSettings": "Accounts and settings",
+    "@accountsAndSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
     "activatedEndToEndEncryption": "🔐 {username} activated end to end encryption",
     "@activatedEndToEndEncryption": {
         "type": "String",

--- a/lib/pages/chat_list/client_chooser_button.dart
+++ b/lib/pages/chat_list/client_chooser_button.dart
@@ -181,7 +181,7 @@ class ClientChooserButton extends StatelessWidget {
         color: Colors.transparent,
         child: PopupMenuButton<Object>(
           key: Key('accounts_and_settings_buttons'),
-          tooltip: 'Accounts and settings',
+          tooltip: L10n.of(context).accountsAndSettings,
           onSelected: (o) => _clientSelected(o, context),
           itemBuilder: _bundleMenuItems,
           icon: Avatar(


### PR DESCRIPTION
Fixes #3524.

The `PopupMenuButton` tooltip in `lib/pages/chat_list/client_chooser_button.dart` was a hardcoded English string, so it stayed in English regardless of the app locale — visible to sighted users on long-press/hover and read out by screen readers.

Added an `accountsAndSettings` key to `intl_en.arb` and switched the tooltip to `L10n.of(context).accountsAndSettings`. Weblate will pick up the new key on the next sync; existing locales fall back to the English template until translated, so no other ARB files needed to change in this PR.

- [x] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md).

### Pull Request has been tested on:

- [x] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS