### PR TITLE
fix pages closing with dialogs opened instead of dialogs closing. Fixes #2709, #3272, #2495

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -34,6 +34,7 @@
         android:allowBackup="false"
         android:fullBackupContent="false"
         android:localeConfig="@xml/locale_config"
+        android:enableOnBackInvokedCallback="false"
     >
         <activity
             android:name=".MainActivity"


### PR DESCRIPTION
Fixes #2709, #3272, #2495

- [x] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [x] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [x] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

The reason for this issue is that modals are being called imperatively, so go_router gets confused and predictive back gestures closes the window instead of the modal.

Disabling predictive back gestures on the app completely is a workaround for this issue.