### PR TITLE
fix(flutter-engine): keep engine alive across activity recreation (#3303)

### DIFF
--- a/android/app/src/main/kotlin/chat/fluffy/fluffychat/MainActivity.kt
+++ b/android/app/src/main/kotlin/chat/fluffy/fluffychat/MainActivity.kt
@@ -1,9 +1,11 @@
 package chat.fluffy.fluffychat
 
+import android.content.Context
+import android.os.Bundle
 import io.flutter.embedding.android.FlutterFragmentActivity
 import io.flutter.embedding.engine.FlutterEngine
-
-import android.content.Context
+import io.flutter.embedding.engine.FlutterEngineCache
+import io.flutter.embedding.engine.dart.DartExecutor
 
 class MainActivity : FlutterFragmentActivity() {
 
@@ -11,9 +13,45 @@ class MainActivity : FlutterFragmentActivity() {
         super.attachBaseContext(base)
     }
 
+    /**
+     * The shared engine must be present in the [FlutterEngineCache] before the
+     * framework creates the FlutterFragment (which happens in super.onCreate()).
+     * In cached-engine mode the fragment resolves the engine by
+     * [getCachedEngineId] and throws an IllegalStateException if it is not in
+     * the cache yet.
+     */
+    override fun onCreate(savedInstanceState: Bundle?) {
+        provideEngine(applicationContext)
+        super.onCreate(savedInstanceState)
+    }
 
-    override fun provideFlutterEngine(context: Context): FlutterEngine? {
-        return provideEngine(this)
+    /**
+     * Registering the engine under a fixed id makes FlutterFragmentActivity run
+     * in "cached engine" mode: the engine is looked up in the
+     * FlutterEngineCache and is NOT destroyed when this activity is destroyed.
+     *
+     * Background: previously the engine was handed over through
+     * provideFlutterEngine() while the activity ran in "new engine" mode. The
+     * FlutterFragment built in that mode hardcodes destroyEngineWithFragment =
+     * true, so the framework destroyed our shared engine in onDestroy(), while
+     * the static [engine] reference kept pointing at the dead engine. The next
+     * MainActivity instance (e.g. after a notification relaunch, task clear or
+     * process restore) then attached that destroyed engine and crashed on its
+     * first layout pass with:
+     *
+     *   java.lang.RuntimeException: Cannot execute operation because
+     *   FlutterJNI is not attached to native.
+     *       at io.flutter.embedding.engine.FlutterJNI.ensureAttachedToNative
+     *       at io.flutter.embedding.engine.FlutterJNI.setViewportMetrics
+     *       at io.flutter.embedding.engine.renderer.FlutterRenderer...
+     *       at FlutterView.onSizeChanged
+     *
+     * Note: do not reintroduce a provideFlutterEngine() override here. In
+     * cached-engine mode it is never consulted, and if getCachedEngineId() is
+     * ever removed it would bring the bug back.
+     */
+    override fun getCachedEngineId(): String? {
+        return ENGINE_ID
     }
 
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
@@ -21,9 +59,23 @@ class MainActivity : FlutterFragmentActivity() {
     }
 
     companion object {
+        private const val ENGINE_ID = "fluffychat_main_engine"
+
         var engine: FlutterEngine? = null
+
+
         fun provideEngine(context: Context): FlutterEngine {
-            val eng = engine ?: FlutterEngine(context, emptyArray(), true, false)
+            val cache = FlutterEngineCache.getInstance()
+            val eng = cache.get(ENGINE_ID)
+                ?: FlutterEngine(context.applicationContext, emptyArray(), true, false)
+                    .also {
+                        // In cached-engine mode the framework does NOT run the Dart
+                        // entrypoint for us (doInitialFlutterViewRun() returns early
+                        // when getCachedEngineId() != null). We must start main()
+                        // ourselves or the view stays blank (0x0, black screen).
+                        it.dartExecutor.executeDartEntrypoint(DartExecutor.DartEntrypoint.createDefault())
+                    }
+                    .also { cache.put(ENGINE_ID, it) }
             engine = eng
             return eng
         }


### PR DESCRIPTION
@krille-chan I have read the CONTRIBUTING.md, but I decided to write this PR, even though the bug was fixed by an LLM. You can do what you want with this, I can only offer this fix.
Tests were done manually on an Android Phone (Pixel 7a).


- [X] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [X] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

---

# Below is the LLM generated PR-Description:

---

## Fix #3303 — "Cannot execute operation because FlutterJNI is not attached to native"

### What / why
`MainActivity` kept a process-global `FlutterEngine` in a static field and handed it
over via `provideFlutterEngine()`. That runs the activity in Flutter's **new-engine**
mode, where `FlutterFragment` hardcodes `destroyEngineWithFragment = true`. So on
activity destruction the framework destroyed our shared engine, while the static
`engine` reference kept pointing at the dead instance.

The next `MainActivity` (notification relaunch, task-clear/launcher relaunch of the
`singleTask` activity, or process restore) attached that destroyed engine and crashed
on its first layout pass:

    java.lang.RuntimeException: Cannot execute operation because FlutterJNI is not
    attached to native.
        at io.flutter.embedding.engine.FlutterJNI.ensureAttachedToNative
        at io.flutter.embedding.engine.FlutterJNI.setViewportMetrics
        at io.flutter.embedding.engine.renderer.FlutterRenderer...
        at FlutterView.onSizeChanged

### The fix
Switch to Flutter's **cached-engine** mode so the engine outlives the activity:
- `getCachedEngineId()` returns a fixed id → the fragment looks the engine up in
  `FlutterEngineCache` and does **not** destroy it with the activity.
- The engine is registered in the cache inside `onCreate` *before* `super.onCreate()`
  (cached mode throws `IllegalStateException` if the engine isn't cached yet).
- The Dart entrypoint is started explicitly (`executeDartEntrypoint(createDefault())`)
  when the engine is first built. In cached mode the framework's
  `doInitialFlutterViewRun()` returns early, so this is required — omitting it leaves
  the view unpainted (0x0, black screen).

### Verification (A/B, same device, same account)
Device: Pixel 7a, Android 17. Repro: destroy the activity while the process stays
alive (task-clear + immediate relaunch) — the exact `performDestroy → performCreate`
same-PID sequence from the crash reports.

- **Baseline (2.8.0 / build 3558):** 19/20 iterations crash with the exact
  "FlutterJNI is not attached" signature.
- **Fixed build:** 0/20 crashes; process PID stable across all 20 same-PID iterations
  (engine survives activity destruction).
- State (composer draft) survives a relaunch; no re-login.

### Notes
- Single file changed: `android/app/src/main/kotlin/chat/fluffy/fluffychat/MainActivity.kt`.
- Does not reintroduce a `provideFlutterEngine()` override (it is never consulted in
  cached mode, and if `getCachedEngineId()` were ever removed it would bring the bug
  back).