### PR TITLE
Fix: deep link handling should popup account select on multi-account …

### DIFF
--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -1268,6 +1268,11 @@
     },
     "oneClientLoggedOut": "One of your clients has been logged out",
     "addAccount": "Add account",
+    "chooseAccount": "Choose account",
+    "@chooseAccount": {
+        "type": "String",
+        "placeholders": {}
+    },
     "editBundlesForAccount": "Edit bundles for this account",
     "addToBundle": "Add to bundle",
     "removeFromBundle": "Remove from this bundle",

--- a/lib/utils/url_launcher.dart
+++ b/lib/utils/url_launcher.dart
@@ -6,6 +6,7 @@
 import 'package:collection/collection.dart' show IterableExtension;
 import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/widgets/adaptive_dialogs/client_picker_dialog.dart';
 import 'package:fluffychat/widgets/adaptive_dialogs/show_ok_cancel_alert_dialog.dart';
 import 'package:fluffychat/widgets/adaptive_dialogs/user_dialog.dart';
 import 'package:fluffychat/widgets/future_loading_dialog.dart';
@@ -129,6 +130,15 @@ class UrlLauncher {
       AppConfig.deepLinkPrefix,
       AppConfig.inviteLinkPrefix,
     );
+
+    // With multiple accounts, let the user choose which account should
+    // handle this link. The chosen client is set as active client so that
+    // all following actions use it.
+    if (matrix.isMultiAccount) {
+      final client = await showClientPickerDialog(context);
+      if (client == null || !context.mounted) return;
+      matrix.setActiveClient(client);
+    }
 
     // The identifier might be a matrix.to url and needs escaping. Or, it might have multiple
     // identifiers (room id & event id), or it might also have a query part.

--- a/lib/widgets/adaptive_dialogs/client_picker_dialog.dart
+++ b/lib/widgets/adaptive_dialogs/client_picker_dialog.dart
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: 2019-Present Christian Kußowski
+// SPDX-FileCopyrightText: 2019-Present Contributors to FluffyChat
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/utils/show_scaffold_dialog.dart';
+import 'package:fluffychat/widgets/adaptive_dialogs/adaptive_dialog_action.dart';
+import 'package:fluffychat/widgets/avatar.dart';
+import 'package:fluffychat/widgets/matrix.dart';
+import 'package:material_ui/material_ui.dart';
+import 'package:matrix/matrix.dart';
+
+/// A reusable dialog which lets the user pick one of the logged in
+/// accounts (clients). Returns the selected [Client] or `null` if the
+/// dialog was dismissed.
+///
+/// Shows nothing and returns the current client directly if there is
+/// only a single account.
+Future<Client?> showClientPickerDialog(
+  BuildContext context, {
+  String? title,
+}) async {
+  final matrix = Matrix.of(context);
+  final clients = matrix.widget.clients.where((client) => client.isLogged());
+  if (clients.length < 2) {
+    return clients.isEmpty ? null : matrix.client;
+  }
+  return showScaffoldDialog<Client>(
+    context: context,
+    containerColor: Colors.transparent,
+    builder: (context) => ClientPickerDialog(
+      clients: clients.toList(),
+      title: title ?? L10n.of(context).chooseAccount,
+    ),
+  );
+}
+
+class ClientPickerDialog extends StatelessWidget {
+  final List<Client> clients;
+  final String title;
+
+  const ClientPickerDialog({
+    required this.clients,
+    required this.title,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog.adaptive(
+      title: Text(title),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          for (final client in clients)
+            ListTile(
+              leading: FutureBuilder<Profile?>(
+                future: client.fetchOwnProfile(),
+                builder: (context, snapshot) {
+                  final displayname =
+                      snapshot.data?.displayName ??
+                      client.userID?.localpart ??
+                      client.userID ??
+                      '';
+                  return Avatar(
+                    mxContent: snapshot.data?.avatarUrl,
+                    name: displayname,
+                    size: 40,
+                  );
+                },
+              ),
+              title: Text(
+                client.userID?.localpart ?? client.userID ?? '',
+                overflow: TextOverflow.ellipsis,
+              ),
+              subtitle: client.homeserver != null
+                  ? Text(
+                      client.homeserver.toString(),
+                      overflow: TextOverflow.ellipsis,
+                    )
+                  : null,
+              onTap: () => Navigator.of(context).pop(client),
+            ),
+        ],
+      ),
+      actions: [
+        AdaptiveDialogAction(
+          onPressed: () => Navigator.of(context).pop(),
+          child: Text(L10n.of(context).cancel),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/widgets/adaptive_dialogs/client_picker_dialog.dart
+++ b/lib/widgets/adaptive_dialogs/client_picker_dialog.dart
@@ -4,9 +4,9 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import 'package:fluffychat/l10n/l10n.dart';
-import 'package:fluffychat/utils/show_scaffold_dialog.dart';
-import 'package:fluffychat/widgets/adaptive_dialogs/adaptive_dialog_action.dart';
+import 'package:fluffychat/widgets/adaptive_dialogs/show_modal_action_popup.dart';
 import 'package:fluffychat/widgets/avatar.dart';
+import 'package:fluffychat/widgets/future_loading_dialog.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 import 'package:material_ui/material_ui.dart';
 import 'package:matrix/matrix.dart';
@@ -17,79 +17,54 @@ import 'package:matrix/matrix.dart';
 ///
 /// Shows nothing and returns the current client directly if there is
 /// only a single account.
-Future<Client?> showClientPickerDialog(
-  BuildContext context, {
-  String? title,
-}) async {
+Future<Client?> showClientPickerDialog(BuildContext context) async {
   final matrix = Matrix.of(context);
   final clients = matrix.widget.clients.where((client) => client.isLogged());
+
   if (clients.length < 2) {
     return clients.isEmpty ? null : matrix.client;
   }
-  return showScaffoldDialog<Client>(
+
+  final profiles = (await showFutureLoadingDialog(
     context: context,
-    containerColor: Colors.transparent,
-    builder: (context) => ClientPickerDialog(
-      clients: clients.toList(),
-      title: title ?? L10n.of(context).chooseAccount,
+    future: () => Future.wait(
+      clients.map((client) async {
+        try {
+          return await client.fetchOwnProfile();
+        } catch (_) {
+          return Profile(
+            userId: client.userID ?? '',
+            displayName: client.userID?.localpart ?? client.userID ?? '',
+            avatarUrl: null,
+          );
+        }
+      }),
     ),
+  )).result;
+
+  if (profiles == null || !context.mounted) return null;
+
+  return showModalActionPopup<Client>(
+    context: context,
+    title: L10n.of(context).chooseAccount,
+    cancelLabel: L10n.of(context).cancel,
+    actions: [
+      for (final (i, client) in clients.indexed)
+        () {
+          final name =
+              profiles[i].displayName ??
+              client.userID?.localpart ??
+              client.userID ??
+              '';
+          return AdaptiveModalAction(
+            label: name,
+            value: client,
+            isDefaultAction: i == 0,
+            icon: profiles[i].avatarUrl != null
+                ? Avatar(mxContent: profiles[i].avatarUrl, name: name, size: 40)
+                : null,
+          );
+        }(),
+    ],
   );
-}
-
-class ClientPickerDialog extends StatelessWidget {
-  final List<Client> clients;
-  final String title;
-
-  const ClientPickerDialog({
-    required this.clients,
-    required this.title,
-    super.key,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    return AlertDialog.adaptive(
-      title: Text(title),
-      content: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          for (final client in clients)
-            ListTile(
-              leading: FutureBuilder<Profile?>(
-                future: client.fetchOwnProfile(),
-                builder: (context, snapshot) {
-                  final displayname =
-                      snapshot.data?.displayName ??
-                      client.userID?.localpart ??
-                      client.userID ??
-                      '';
-                  return Avatar(
-                    mxContent: snapshot.data?.avatarUrl,
-                    name: displayname,
-                    size: 40,
-                  );
-                },
-              ),
-              title: Text(
-                client.userID?.localpart ?? client.userID ?? '',
-                overflow: TextOverflow.ellipsis,
-              ),
-              subtitle: client.homeserver != null
-                  ? Text(
-                      client.homeserver.toString(),
-                      overflow: TextOverflow.ellipsis,
-                    )
-                  : null,
-              onTap: () => Navigator.of(context).pop(client),
-            ),
-        ],
-      ),
-      actions: [
-        AdaptiveDialogAction(
-          onPressed: () => Navigator.of(context).pop(),
-          child: Text(L10n.of(context).cancel),
-        ),
-      ],
-    );
-  }
 }

--- a/lib/widgets/adaptive_dialogs/client_picker_dialog.dart
+++ b/lib/widgets/adaptive_dialogs/client_picker_dialog.dart
@@ -18,11 +18,10 @@ import 'package:matrix/matrix.dart';
 /// Shows nothing and returns the current client directly if there is
 /// only a single account.
 Future<Client?> showClientPickerDialog(BuildContext context) async {
-  final matrix = Matrix.of(context);
-  final clients = matrix.widget.clients.where((client) => client.isLogged());
+  final clients = Matrix.of(context).widget.clients;
 
   if (clients.length < 2) {
-    return clients.isEmpty ? null : matrix.client;
+    return clients.isEmpty ? null : clients.first;
   }
 
   final profiles = (await showFutureLoadingDialog(
@@ -34,7 +33,10 @@ Future<Client?> showClientPickerDialog(BuildContext context) async {
         } catch (_) {
           return Profile(
             userId: client.userID ?? '',
-            displayName: client.userID?.localpart ?? client.userID ?? '',
+            displayName:
+                client.userID?.localpart ??
+                client.userID ??
+                L10n.of(context).user,
             avatarUrl: null,
           );
         }
@@ -55,14 +57,16 @@ Future<Client?> showClientPickerDialog(BuildContext context) async {
               profiles[i].displayName ??
               client.userID?.localpart ??
               client.userID ??
-              '';
+              L10n.of(context).user;
           return AdaptiveModalAction(
             label: name,
             value: client,
             isDefaultAction: i == 0,
-            icon: profiles[i].avatarUrl != null
-                ? Avatar(mxContent: profiles[i].avatarUrl, name: name, size: 40)
-                : null,
+            icon: Avatar(
+              mxContent: profiles[i].avatarUrl,
+              name: name,
+              size: 40,
+            ),
           );
         }(),
     ],

--- a/lib/widgets/adaptive_dialogs/show_modal_action_popup.dart
+++ b/lib/widgets/adaptive_dialogs/show_modal_action_popup.dart
@@ -105,7 +105,7 @@ Future<T?> showModalActionPopup<T>({
 class AdaptiveModalAction<T> {
   final String label;
   final T value;
-  Icon? icon;
+  Widget? icon;
   final bool isDefaultAction;
   final bool isDestructive;
 


### PR DESCRIPTION
# Summary
* Add user select behavior before deep-link handling so that the user is capable of selecting which account should handle the link.

<img width="547" height="556" alt="image" src="https://github.com/user-attachments/assets/59e98a62-1d45-4a40-b8b5-0000c55eecaf" />

- [x] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [x] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS